### PR TITLE
Revert "implied relationship fix"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@ target/
 schemaspy.iml
 .project
 .classpath
-/bin/
-.settings

--- a/src/main/java/org/schemaspy/DbAnalyzer.java
+++ b/src/main/java/org/schemaspy/DbAnalyzer.java
@@ -62,7 +62,6 @@ public class DbAnalyzer {
                 	Table existingTable = keyedTablesByPrimary.get(primary);
                     duplicatePrimaries = addKeyedTablesByPrimary(keyedTablesByPrimary, duplicatePrimaries, table, primary, existingTable);
 
-                    primary = new DatabaseObject(tableColumn);
                     primary.setName(table.getName()+primary.getName());
                     existingTable = keyedTablesByPrimary.get(primary);
                     duplicatePrimaries = addKeyedTablesByPrimary(keyedTablesByPrimary, duplicatePrimaries, table, primary, existingTable);
@@ -86,8 +85,8 @@ public class DbAnalyzer {
 
         List<ImpliedForeignKeyConstraint> impliedConstraints = new ArrayList<ImpliedForeignKeyConstraint>();
         for (TableColumn childColumn : columnsWithoutParents) {
+            Table primaryTable = keyedTablesByPrimary.get(new DatabaseObject(childColumn));
             DatabaseObject column = new DatabaseObject(childColumn);
-            Table primaryTable = keyedTablesByPrimary.get(column);
             if (primaryTable == null) {
                 column.setName(childColumn.getTable().getName()+childColumn.getName());
                 primaryTable = keyedTablesByPrimary.get(column);


### PR DESCRIPTION
Reverts schemaspy/schemaspy#19

Reverse back changes from Merge pull request #19 from ismailsimsek/impliedrel
implied relationship fix

Unfortunately something is not working as should, for my large database I have to many implied relationship. To many  implied relationship also prolonged total time of diagram generation from few minutes to several dozen minutes.

Today to master branch I will commit new version of SchemaSpy with DbAnalyzerTest for cover test  DbAnalyzer.getImpliedConstraints. If in your opinion current solution is working incorrectly please prepare test with your data and be sure that changes made by you covering also existing testes.