### PR TITLE
Fix for issue #193: Non-zero error code when querying multiple schemas

### DIFF
--- a/src/main/java/org/schemaspy/Main.java
+++ b/src/main/java/org/schemaspy/Main.java
@@ -49,7 +49,7 @@ public class Main {
         int rc = 1;
 
         try {
-            rc = analyzer.analyze(new Config(argv)) == null ? 1 : 0;
+            rc = analyzer.analyze(new Config(argv)) ? 0 : 1;
         } catch (ConnectionFailure couldntConnect) {
             // failure already logged
             rc = 3;

--- a/src/main/java/org/schemaspy/SchemaAnalyzer.java
+++ b/src/main/java/org/schemaspy/SchemaAnalyzer.java
@@ -74,7 +74,7 @@ public class SchemaAnalyzer {
     @Autowired
     private DatabaseService databaseService;
 
-    public Database analyze(Config config) throws SQLException, IOException {
+    public boolean analyze(Config config) throws SQLException, IOException {
     	// don't render console-based detail unless we're generating HTML (those probably don't have a user watching)
     	// and not already logging fine details (to keep from obfuscating those)
         boolean render = config.isHtmlGenerationEnabled() && !fineEnabled;
@@ -83,16 +83,16 @@ public class SchemaAnalyzer {
         return analyze(config, progressListener);
     }
 
-    public Database analyze(Config config, ProgressListener progressListener) throws SQLException, IOException {
+    public boolean analyze(Config config, ProgressListener progressListener) throws SQLException, IOException {
         try {
             if (config.isHelpRequired()) {
                 config.dumpUsage(null, false);
-                return null;
+                return false;
             }
 
             if (config.isDbHelpRequired()) {
                 config.dumpUsage(null, true);
-                return null;
+                return false;
             }
 
             // set the log level for the root logger
@@ -127,7 +127,7 @@ public class SchemaAnalyzer {
                 String dbName = config.getDb();
 
                 MultipleSchemaAnalyzer.getInstance().analyze(dbName, schemas, args, config);
-                return null;
+                return true;
             }
 
             String dbName = config.getDb();
@@ -269,10 +269,10 @@ public class SchemaAnalyzer {
                 }
             }
 
-            return db;
+            return true;
         } catch (Config.MissingRequiredParameterException missingParam) {
             config.dumpUsage(missingParam.getMessage(), missingParam.isDbTypeSpecific());
-            return null;
+            return false;
         }
     }
 


### PR DESCRIPTION
See original [SourceForge bug #193](https://sourceforge.net/p/schemaspy/bugs/193/)

When inspecting multiple schemas (i.e. using the `'-all'` or `'-schemas "schema1,schema2"'` option), SchemaSpy's main program entry point will always return a non-zero error code of 1 even if the process succeeds.

This is due to a limitation of the `SchemaAnalyzer.analyze` return type.

@rafalkasa 