### PR TITLE
Refactoring of DBSpecificOption

### DIFF
--- a/src/main/java/org/schemaspy/service/SqlService.java
+++ b/src/main/java/org/schemaspy/service/SqlService.java
@@ -13,7 +13,12 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -74,7 +79,7 @@ public class SqlService {
             for (DbSpecificOption option : urlBuilder.getOptions()) {
                 if (!args.contains("-" + option.getName())) {
                     args.add("-" + option.getName());
-                    args.add(option.getValue().toString());
+                    args.add(option.getValue());
                 }
             }
 
@@ -87,6 +92,7 @@ public class SqlService {
 
         return meta;
     }
+
     /**
      * Create a <code>PreparedStatement</code> from the specified SQL.
      * The SQL can contain these named parameters (but <b>not</b> question marks).
@@ -95,10 +101,11 @@ public class SqlService {
      * <li>:owner - alias for :schema
      * <li>:table - replaced with the name of the table
      * </ol>
-     * @param sql String - SQL without question marks
+     *
+     * @param sql       String - SQL without question marks
      * @param tableName String - <code>null</code> if the statement doesn't deal with <code>Table</code>-level details.
-     * @throws SQLException
      * @return PreparedStatement
+     * @throws SQLException
      */
     public PreparedStatement prepareStatement(String sql, String tableName) throws SQLException {
         StringBuilder sqlBuf = new StringBuilder(sql);
@@ -123,10 +130,9 @@ public class SqlService {
      * Replaces named parameters in <code>sql</code> with question marks and
      * returns appropriate matching values in the returned <code>List</code> of <code>String</code>s.
      *
-     * @param sql StringBuffer input SQL with named parameters, output named params are replaced with ?'s.
+     * @param sql       StringBuffer input SQL with named parameters, output named params are replaced with ?'s.
      * @param tableName String
      * @return List of Strings
-     *
      * @see #prepareStatement(String, String)
      */
     private List<String> getSqlParams(String schema, String name, StringBuilder sql, String tableName) {

--- a/src/main/java/org/schemaspy/util/ConnectionURLBuilder.java
+++ b/src/main/java/org/schemaspy/util/ConnectionURLBuilder.java
@@ -18,11 +18,12 @@
  */
 package org.schemaspy.util;
 
+import org.schemaspy.Config;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
-import org.schemaspy.Config;
 
 /**
  * @author John Currier
@@ -71,7 +72,7 @@ public class ConnectionURLBuilder {
             logger.fine(option.toString());
 
             // replace e.g. <host> with myDbHost
-            connectionSpec = connectionSpec.replaceAll("\\<" + option.getName() + "\\>", option.getValue().toString());
+            connectionSpec = connectionSpec.replaceAll("\\<" + option.getName() + "\\>", option.getValue());
         }
 
         return connectionSpec;
@@ -98,12 +99,12 @@ public class ConnectionURLBuilder {
         if (paramIndex < 0) {
             if (config != null)
                 param = config.getParam(option.getName());  // not in args...might be one of
-                                                            // the common db params
+            // the common db params
             if (param == null)
                 throw new Config.MissingRequiredParameterException(option.getName(), option.getDescription(), true);
         } else {
             args.remove(paramIndex);
-            param = args.get(paramIndex).toString();
+            param = args.get(paramIndex);
             args.remove(paramIndex);
         }
 

--- a/src/main/java/org/schemaspy/util/DbSpecificOption.java
+++ b/src/main/java/org/schemaspy/util/DbSpecificOption.java
@@ -18,33 +18,32 @@
  */
 package org.schemaspy.util;
 
-public class DbSpecificOption {
+import java.util.Objects;
+
+public final class DbSpecificOption {
     private final String name;
-    private       Object value;
+    private String value;
     private final String description;
 
-    public DbSpecificOption(String name, String value, String description) {
-        this.name = name;
-        this.value = value;
-        this.description = description;
-    }
-
     public DbSpecificOption(String name, String description) {
-        this(name, null, description);
+        this.name = Objects.requireNonNull(name);
+        this.description = description;
     }
 
     public String getName() {
         return name;
     }
 
-    public Object getValue() {
+    //TODO This method may return null. Consider changing the return type to Optional<String> and return Optional.empty instead of null
+    public String getValue() {
         return value;
     }
 
-    public void setValue(Object value) {
+    public void setValue(String value) {
         this.value = value;
     }
 
+    //TODO This method may return null. Consider changing the return type to Optional<String> and return Optional.empty instead of null
     public String getDescription() {
         return description;
     }

--- a/src/test/java/org/schemaspy/util/DbSpecificOptionTest.java
+++ b/src/test/java/org/schemaspy/util/DbSpecificOptionTest.java
@@ -1,0 +1,16 @@
+package org.schemaspy.util;
+
+import org.hamcrest.core.IsNull;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+
+public class DbSpecificOptionTest {
+
+    @Test
+    public void valueOfOptionCanBeNull() {
+        DbSpecificOption dbSpecificOption = new DbSpecificOption("MyOption", "MyDescription");
+        assertThat(dbSpecificOption.getValue(), IsNull.nullValue());
+    }
+}


### PR DESCRIPTION
Remove the second unused constructor and change the type of the 'value'
field to String as it cannot be any other Object by now. The other changes are mainly code style changes.
As #getValue returns only String then the callers do not need to call
toString on the returned values.

_(I used IntelliJ IDEA 2016.3.2 Build #IU-163.10154.41)_
