### PR TITLE
`-all` flag causes schemaspy to always exit non-zero code

### DIFF
--- a/src/main/java/org/schemaspy/Config.java
+++ b/src/main/java/org/schemaspy/Config.java
@@ -114,7 +114,7 @@ public class Config
     private Boolean viewsEnabled;
     private Boolean meterEnabled;
     private Boolean railsEnabled;
-    private Boolean evaluteAll;
+    private Boolean evaluateAll;
     private Boolean highQuality;
     private Boolean lowQuality;
     private String schemaSpec;  // used in conjunction with evaluateAll
@@ -137,14 +137,14 @@ public class Config
     {
         if (instance == null)
             setInstance(this);
-        options = new ArrayList<String>();
+        options = new ArrayList<>();
     }
 
     /**
      * Construct a configuration from an array of options (e.g. from a command
      * line interface).
      *
-     * @param options
+     * @param argv
      */
     public Config(String[] argv)
     {
@@ -1125,13 +1125,13 @@ public class Config
     }
 
     public void setEvaluateAllEnabled(boolean enabled) {
-        evaluteAll = enabled;
+        evaluateAll = enabled;
     }
 
     public boolean isEvaluateAllEnabled() {
-        if (evaluteAll == null)
-            evaluteAll = options.remove("-all");
-        return evaluteAll;
+        if (evaluateAll == null)
+            evaluateAll = options.remove("-all");
+        return evaluateAll;
     }
 
     /**

--- a/src/main/java/org/schemaspy/Main.java
+++ b/src/main/java/org/schemaspy/Main.java
@@ -18,17 +18,16 @@
  */
 package org.schemaspy;
 
-import java.util.Arrays;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.schemaspy.model.ConnectionFailure;
 import org.schemaspy.model.EmptySchemaException;
 import org.schemaspy.model.InvalidConfigurationException;
 import org.schemaspy.model.ProcessExecutionException;
-import org.schemaspy.service.TableService;
 import org.schemaspy.ui.MainFrame;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @author John Currier

--- a/src/main/java/org/schemaspy/service/SqlService.java
+++ b/src/main/java/org/schemaspy/service/SqlService.java
@@ -114,9 +114,8 @@ public class SqlService {
                 stmt.setString(i + 1, sqlParams.get(i).toString());
             }
         } catch (SQLException exc) {
-            throw exc;
-        } finally {
             stmt.close();
+            throw exc;
         }
 
         return stmt;


### PR DESCRIPTION
#42 
In this case close shouldn't be called in finally block.