### PR TITLE
Maria DB 5.5 support

### DIFF
--- a/src/main/resources/org/schemaspy/types/mariadb.properties
+++ b/src/main/resources/org/schemaspy/types/mariadb.properties
@@ -1,0 +1,46 @@
+#
+# see http://schemaspy.org/dbtypes.html
+# for configuration / customization details
+#
+
+description=MariaDB
+
+connectionSpec=jdbc:mariadb://<host>:<port>/<db>
+host=hostname host where database resides with optional port
+db=database name
+
+driver=org.mariadb.jdbc.Driver
+
+# return table_schema, table_name, table_comment, table_rows 
+#   for a specific :schema (which MariaDB doesn't have, so the db name will be used)
+#
+# querying table_rows in this manner is significantly faster than the "select count(*)"
+#   implementation, but will be a rough estimate for InnoDB-based tables
+# have table_rows evaluate to null if an approximation isn't appropriate for your situation
+# note: MariaDB's information_schema treats 'schema' as schema while this JDBC driver treats it as catalog
+selectTablesSql=select table_schema as table_catalog, null as table_schema, table_name, table_comment, table_rows from information_schema.tables where table_schema=:schema and table_type='BASE TABLE'
+
+# return view_schema, view_name, view_definition, view_comment
+#   for a specific :schema (which MariaDB doesn't have, so the db name will be used)
+selectViewsSql=select table_schema as view_catalog, null as view_schema, table_name as view_name, view_definition, null as view_comment from information_schema.views where table_schema=:schema
+
+# this should be significantly faster than the default implementation, but will be
+#  a rough estimate for InnoDB-based tables  
+# this is only used for remote tables since row_count was returned in selectTablesSql
+selectRowCountSql=select table_rows row_count from information_schema.tables where table_name=:table 
+
+# return table_name, column_name, column_type, short_column_type for a specific :schema
+# for all column types that have special formatting.
+# short_column_type is optional and is used in the ER diagrams to keep them from becoming bloated
+selectColumnTypesSql=select table_name, column_name, replace(column_type,"','","', '") as column_type, left(column_type, locate("(", column_type)-1) as short_column_type from information_schema.columns where table_schema=:schema and (column_type like 'enum(%' or column_type like 'set(%')
+
+# select any stored procedures and functions
+selectRoutinesSql=select routine_name, routine_type, dtd_identifier, routine_body, routine_definition, is_deterministic, sql_data_access, security_type, sql_mode, routine_comment from information_schema.routines where routine_schema=:schema
+
+# select parameters for stored procedures and functions
+selectRoutineParametersSql=select specific_name, parameter_name, dtd_identifier, parameter_mode from information_schema.parameters where specific_schema=:schema and ordinal_position != 0 order by ordinal_position
+
+# regular expression used in conjunction with -all (and can be command line param '-schemaSpec')
+# this says which schemas to include in our evaluation of "all schemas"
+# this one matches anything other than the listed system tables
+schemaSpec=(?!^mysql$|^performance_schema$|^information_schema$).*


### PR DESCRIPTION
This is pull request extend SchemaSpy for MariaDB support configuration file. Fix MariaDB 5.5.x support? #71

Connection was tested used [MariaDB Connector/J 1.5.9](https://downloads.mariadb.org/connector-java/1.5.9/)

You can two option for prepare the configuration for MariaDB using schemaspy.properties file:

```
schemaspy.t=mariadb

# optional path to alternative jdbc drivers. 
schemaspy.dp=\drivers\mariadb-java-client-1.5.9.jar

# database properties: host, port number, name user, password
schemaspy.host=localhost
schemaspy.port=3306
schemaspy.db=database_name
schemaspy.u=root
schemaspy.p=password

# output dir to save generated files
schemaspy.o=\doc\schemaspy\output

# db scheme for which generate diagrams

schemaspy.charset=UTF-8
```

Configuration by command line parameters:

`java -jar schemaspy.jar -t mariadb -dp \drivers\mariadb-java-client-1.5.9.jar -db dbName -host localhost -port 3306 -u root -p password -o \doc\schemaspy\output -charset=UTF-8`