### PR TITLE
add travis deploy for master build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,9 @@ cache:
   directories:
     - '$HOME/.m2/repository'
     - '$HOME/.sonar/cache'
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $BUILD_DEPLOY_GITHUB_TOKEN # Set in travis-ci.org dashboard
+  on:
+    branch: master


### PR DESCRIPTION
After this change each time when pull request will be merged to the master user can download new SchemaSpy jar version for tests purposes before release.