### PR TITLE
Impala support

### DIFF
--- a/src/main/java/org/schemaspy/Config.java
+++ b/src/main/java/org/schemaspy/Config.java
@@ -106,6 +106,7 @@ public class Config {
     private Boolean lowQuality;
     private Boolean paginationEnabled;
     private String imageFormat;
+    private Boolean loadJDBCJarsEnabled;
     private String schemaSpec;  // used in conjunction with evaluateAll
     private boolean hasOrphans = false;
     private boolean hasRoutines = false;
@@ -1374,6 +1375,32 @@ public class Config {
 
         return paginationEnabled;
     }
+
+
+    /**
+     * If enabled SchemaSpy will load from classpath additional jars used by JDBC Driver<p/>
+     * <p>
+     * Defaults to <code>false</code> (enabled).
+     *
+     * @param enabled
+     */
+    public void setLoadJDBCJarsEnabled(boolean enabled) {
+        loadJDBCJarsEnabled = enabled;
+    }
+
+    /**
+     * @return
+     * @see #setLoadJDBCJarsEnabled(boolean)
+     */
+    public boolean isLoadJDBCJarsEnabled() {
+        String loadJars = pullParam("-loadjars");
+        if (loadJars != null && loadJars.equals("true")) {
+            loadJDBCJarsEnabled = true;
+        }
+
+        return loadJDBCJarsEnabled;
+    }
+
     public void setImageFormat(String imageFormat) {
         this.imageFormat = imageFormat;
     }
@@ -1826,6 +1853,8 @@ public class Config {
             params.add("-noviews");
         if (!isPaginationEnabled())
             params.add("-nopages");
+        if (!isLoadJDBCJarsEnabled())
+            params.add("-loadjars");
         if (isRankDirBugEnabled())
             params.add("-rankdirbug");
         if (isRailsEnabled())

--- a/src/main/java/org/schemaspy/DbDriverLoader.java
+++ b/src/main/java/org/schemaspy/DbDriverLoader.java
@@ -19,7 +19,6 @@
 package org.schemaspy;
 
 import org.schemaspy.model.ConnectionFailure;
-import org.xeustechnologies.jcl.JarClassLoader;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/src/main/resources/org/schemaspy/types/impala.properties
+++ b/src/main/resources/org/schemaspy/types/impala.properties
@@ -1,0 +1,12 @@
+#
+# see http://schemaspy.org/dbtypes.html
+# for configuration / customization details
+#
+
+description=Imapla
+connectionSpec=jdbc:hive2://<host>:<port>/<db>;auth=noSasl
+host=hostname
+db=database name
+port=databse port
+
+driver=com.cloudera.hive.jdbc4.HS2Driver

--- a/src/main/resources/org/schemaspy/types/impala.properties
+++ b/src/main/resources/org/schemaspy/types/impala.properties
@@ -4,9 +4,9 @@
 #
 
 description=Imapla
-connectionSpec=jdbc:hive2://<host>:<port>/<db>;auth=noSasl
+connectionSpec=jdbc:impala://<host>:<port>/<db>
 host=hostname
 db=database name
 port=databse port
 
-driver=com.cloudera.hive.jdbc4.HS2Driver
+driver=com.cloudera.impala.jdbc41.Driver


### PR DESCRIPTION
This PR improve SchemaSpy to support impala database #64 

Impala JDBC driver is quite specific to use this driver with SchemaSpy to the class path more external jars must be added.

You can read more about this here on Cloudera Impala page https://www.cloudera.com/documentation/enterprise/5-9-x/topics/impala_jdbc.html#jdbc_setup

To use impala JDBC driver please set  `-loadjars=true` if enabled SchemaSpy will load to the JAVA classpath additional jars used by JDBC Driver


