### PR TITLE
Set scope 'test' for mockito dependency, remove duplicate scope [enhancement]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,8 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.2.28</version>
+                <version>2.7.22</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.github.spullara.mustache.java</groupId>
@@ -113,12 +114,10 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
The declaration of the mockito dependency was missing the scope and
therefore was falling back to 'compile' scope. This caused the Maven
build to include the transitive dependency 'byte-buddy' in the generated
SchemaSpy jar file.