### PR TITLE
Docker image builds: snapshot and relase

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -1,0 +1,37 @@
+FROM openjdk:8-jre-alpine
+
+ENV LC_ALL=C
+
+ADD entrypoint.sh /
+
+RUN set -o pipefail && \
+    adduser java -h / -D && \
+    apk update && apk add --no-cache curl unzip jq graphviz fontconfig && \
+    cd /tmp && \
+    curl https://www.fontsquirrel.com/fonts/download/open-sans -J -O && \
+    unzip open-sans.zip -d /usr/share/fonts && \
+    rm open-sans.zip && \
+    cd / && \
+    fc-cache -fv && \
+    curl -s https://api.github.com/repos/schemaspy/schemaspy/releases/latest | jq -r ".assets[] | select(.name | test(\"jar\")) | .browser_download_url" | xargs curl -JOL && \
+    echo "export MAIN_CLASS=$(unzip -p schemaspy*.jar META-INF/MANIFEST.MF | grep Main-Class | awk -F ': ' '{sub(/\r/,"",$2);print $2}')" > .env &&\
+    mkdir /drivers && \
+    mkdir /output && \
+    mkdir /config && \
+    chown -R java /schema* && \
+    chown -R java /drivers && \
+    chown -R java /output && \
+    chown -R java /config && \
+    chmod ugo+x entrypoint.sh && \
+    apk del curl unzip jq && \
+    rm -rf /var/cache/*
+
+
+
+USER java
+
+WORKDIR /
+
+VOLUME /drivers /output /config
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/release/entrypoint.sh
+++ b/docker/release/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+source /.env
+exec java -cp *:/drivers/* $MAIN_CLASS -o /output "$@"

--- a/docker/release/readme.md
+++ b/docker/release/readme.md
@@ -1,0 +1,36 @@
+## Docker image for SchemaSpy
+
+### Build info
+
+We currently build and publish release image and snapshot images.
+This are distinguished by tag.
+
+Alpine base with:
+* openjdk8-jre
+* OpenSans font
+* graphviz
+
+### Usage
+Currently the build contains 0 driver.
+
+It exposes 3 volumes that can be mounted
+
+/driver /output /config
+
+The container will load all libraries drivers, it will have output set to /output
+
+Container will exit when finished.
+
+Example:  
+`docker run -v "$PWD/drivers:/driver" -v "$PWD/output:/output" schemaspy:[tag] -t mysql -db [database] -u [user] -p [password] -host [host] -port [port]` 
+
+The example above assumes that the mysql jdbc driver is located in $PWD/drivers  
+and output will be written to $PWD/output.
+
+### Caveats
+If you are new to docker localhost is inside the container and not the dockerhost.  
+-net=host probably doesn't work with docker toolbox or docker for (mac|windows).
+
+## Issues
+Create an issue in the [github project](https://github.com/schemaspy/schemaspy/issues)
+

--- a/docker/snapshot/Dockerfile
+++ b/docker/snapshot/Dockerfile
@@ -1,0 +1,34 @@
+FROM openjdk:8-jre-alpine
+
+ENV LC_ALL=C
+
+RUN adduser java -h / -D && \
+    set -x && \
+    apk add --no-cache curl git unzip graphviz fontconfig openjdk8="$JAVA_ALPINE_VERSION" && \
+    mkdir -p /opt/build && cd /opt/build && \
+    curl https://www.fontsquirrel.com/fonts/download/open-sans -J -O && \
+    unzip open-sans.zip -d /usr/share/fonts && \
+    fc-cache -fv && \
+    git clone https://github.com/schemaspy/schemaspy.git && \
+    cd schemaspy && \
+    ./mvnw package && \
+    cp target/schemaspy*.jar / && \
+    cd / && \doc
+    rm -rf /opt/build && \
+    rm -rf ~/.m2 && \
+    apk del curl git unzip openjdk8 && \
+    mkdir /drivers && \
+    mkdir /output && \
+    mkdir /config && \
+    chown -R java /schema* && \
+    chown -R java /drivers && \
+    chown -R java /output && \
+    chown -R java /config
+
+USER java
+
+WORKDIR /
+
+VOLUME /drivers /output /config
+
+ENTRYPOINT ["java","-cp","*:/drivers/*","org.springframework.boot.loader.JarLauncher", "-o", "/output"]


### PR DESCRIPTION
# Common
They current don't contain any jdbc-drivers.

# Release
* Release contains a small entry script since we have changed the main-class since rc1.
* Release will download the github release artifact.

# Snapshot
* Will git clone the repository and build it.