### PR TITLE
Pinned jre to 8u111, added branch,revision,driver versions as labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,22 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:8u111-jre-alpine
 
 ENV LC_ALL=C
 
+ARG GIT_BRANCH=local
+ARG GIT_REVISION=local
+
 ENV MYSQL_VERSION=6.0.6
+ENV MARIADB_VERSION=1.1.10
+ENV POSTGRESQL_VERSION=42.1.1
+ENV JTDS_VERSION=1.3.1
+
+LABEL MYSQL_VERSION=$MYSQL_VERSION
+LABEL MARIADB_VERSION=$MARIADB_VERSION
+LABEL POSTGRESQL_VERSION=$POSTGRESQL_VERSION
+LABEL JTDS_VERSION=$JTDS_VERSION
+
+LABEL GIT_BRANCH=$GIT_BRANCH
+LABEL GIT_REVISION=$GIT_REVISION
 
 RUN adduser java -h / -D && \
     set -x && \
@@ -15,10 +29,10 @@ RUN adduser java -h / -D && \
     rm -f /tmp/open-sans.zip && \
     mkdir /drivers_inc && \
     cd /drivers_inc && \
-    curl -JLO http://search.maven.org/remotecontent?filepath=mysql/mysql-connector-java/6.0.6/mysql-connector-java-6.0.6.jar && \
-    curl -JLO http://search.maven.org/remotecontent?filepath=org/mariadb/jdbc/mariadb-java-client/1.1.10/mariadb-java-client-1.1.10.jar && \
-    curl -JLO http://search.maven.org/remotecontent?filepath=org/postgresql/postgresql/42.1.1.jre7/postgresql-42.1.1.jre7.jar && \
-    curl -JLO http://search.maven.org/remotecontent?filepath=net/sourceforge/jtds/jtds/1.3.1/jtds-1.3.1.jar && \
+    curl -JLO http://search.maven.org/remotecontent?filepath=mysql/mysql-connector-java/$MYSQL_VERSION/mysql-connector-java-$MYSQL_VERSION.jar && \
+    curl -JLO http://search.maven.org/remotecontent?filepath=org/mariadb/jdbc/mariadb-java-client/$MARIADB_VERSION/mariadb-java-client-$MARIADB_VERSION.jar && \
+    curl -JLO http://search.maven.org/remotecontent?filepath=org/postgresql/postgresql/$POSTGRESQL_VERSION.jre7/postgresql-$POSTGRESQL_VERSION.jre7.jar && \
+    curl -JLO http://search.maven.org/remotecontent?filepath=net/sourceforge/jtds/jtds/$JTDS_VERSION/jtds-$JTDS_VERSION.jar && \
     mkdir /drivers && \
     mkdir /output && \
     mkdir /config && \

--- a/docker.sh
+++ b/docker.sh
@@ -6,7 +6,7 @@ REPO=schemaspy/schemaspy
 
 function build() {
     echo "Building docker image"
-    docker build -t ${REPO}:snapshot .
+    docker build -t ${REPO}:snapshot --build-arg GIT_BRANCH=$TRAVIS_BRANCH --build-arg GIT_REVISION=$TRAVIS_COMMIT .
 }
 
 function deploy() {


### PR DESCRIPTION
fixes #122 

This might break if openjdk remove the 8u111 image.
To avoid it we could.....copy the dockerfile for 8u111 and just add our stuff in the end.