### PR TITLE
Added JDBC Type 4 Driver Access to DB2/zos

### DIFF
--- a/src/main/resources/org/schemaspy/types/db2net.properties
+++ b/src/main/resources/org/schemaspy/types/db2net.properties
@@ -9,7 +9,7 @@ description=IBM DB2 with the Type 4 'Net' Driver
 extends=db2
 
 # use the 'net' driver (Type 4) instead of the default 'app' driver
-driver=COM.ibm.db2.jdbc.net.DB2Driver
+driver=com.ibm.db2.jcc.DB2Driver
 
 connectionSpec=jdbc:db2://<host>:<port>/<db>
 host=database host

--- a/src/main/resources/org/schemaspy/types/db2zosnet.properties
+++ b/src/main/resources/org/schemaspy/types/db2zosnet.properties
@@ -1,0 +1,19 @@
+#
+# see http://schemaspy.org/dbtypes.html
+# for configuration / customization details
+#
+
+# details in db2.properties:
+extends=db2net
+
+# z/OS-specific implementation provided by Christian Riedel
+description=IBM DB2/zos with the Type 4 'Net' Driver
+
+# return text that represents a specific :view / :schema
+selectViewSql=select TEXT from SYSIBM.SYSVIEWS where NAME=:view and CREATOR=:schema
+
+# return table_name, constraint_name and text for a specific :schema
+selectCheckConstraintsSql=select CHECKNAME constraint_name, TBNAME table_name, CHECKCONDITION from SYSIBM.SYSCHECKS where TBOWNER=:schema
+
+selectTableIdsSql=select OBID table_id, NAME table_name from SYSIBM.SYSTABLES where CREATOR=:schema
+selectIndexIdsSql=select OBID index_id, NAME index_name, TBNAME table_name from SYSIBM.SYSINDEXES where TBCREATOR=:schema


### PR DESCRIPTION
Changed the package of the db2net Driver.
Added a db2zosnet.properties to get a jdbc type 4 access to a db2z-database.