### PR TITLE
Add table name in to HTML title tag

### DIFF
--- a/src/main/java/org/schemaspy/view/HtmlTablePage.java
+++ b/src/main/java/org/schemaspy/view/HtmlTablePage.java
@@ -37,16 +37,6 @@ import java.util.*;
 public class HtmlTablePage extends HtmlFormatter {
     private static final HtmlTablePage instance = new HtmlTablePage();
 
-    private final Map<String, String> defaultValueAliases = new HashMap<>();
-
-    {
-        defaultValueAliases.put("CURRENT TIMESTAMP", "now"); // DB2
-        defaultValueAliases.put("CURRENT TIME", "now");      // DB2
-        defaultValueAliases.put("CURRENT DATE", "now");      // DB2
-        defaultValueAliases.put("SYSDATE", "now");           // Oracle
-        defaultValueAliases.put("CURRENT_DATE", "now");      // Oracle
-    }
-
     /**
      * Singleton: Don't allow instantiation
      */

--- a/src/main/java/org/schemaspy/view/MustacheWriter.java
+++ b/src/main/java/org/schemaspy/view/MustacheWriter.java
@@ -64,6 +64,7 @@ public class MustacheWriter {
             mainScope.put("rootPath", rootPath);
             mainScope.put("rootPathtoHome", rootPathtoHome);
             mainScope.put("isMultipleSchemas", isMultipleSchemas);
+            mainScope.putAll(scopes);
 
             Mustache mustacheContent = contentMf.compile(getReader("container.html"), "container");
             mustacheContent.execute(content, mainScope).flush();

--- a/src/main/resources/layout/container.html
+++ b/src/main/resources/layout/container.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>{{databaseName}} Database</title>
+  <title>{{#table}}{{table.name}} - {{/table}}{{databaseName}} Database</title>
   <!-- Tell the browser to be responsive to screen width -->
   <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
   <!-- Bootstrap 3.3.5 -->


### PR DESCRIPTION
This PR add contextual information to the tables pages for example ABC table page will have a title like <title>ABC table - XYZ Database</title>.

This PR fix issue #136 