### PR TITLE
Display on main page database description in HTML

### DIFF
--- a/src/main/java/org/schemaspy/view/HtmlMainIndexPage.java
+++ b/src/main/java/org/schemaspy/view/HtmlMainIndexPage.java
@@ -24,7 +24,6 @@ import java.util.*;
 
 import org.schemaspy.DbAnalyzer;
 import org.schemaspy.model.Database;
-import org.schemaspy.model.ForeignKeyConstraint;
 import org.schemaspy.model.Table;
 import org.schemaspy.util.Markdown;
 
@@ -64,7 +63,7 @@ public class HtmlMainIndexPage extends HtmlFormatter {
         tmp = new TreeSet<Table>(sorter);
         tmp.addAll(remotes);
 
-        String databaseName = getDatabaseDescription(database);
+        String databaseName = getDatabaseName(database);
 
         List<MustacheTable> mustacheTables = new ArrayList<>();
 
@@ -91,6 +90,7 @@ public class HtmlMainIndexPage extends HtmlFormatter {
         scopes.put("tables", mustacheTables);
         scopes.put("database", database);
         scopes.put("databaseName", databaseName);
+        scopes.put("description", database.getDescription());
         scopes.put("paginationEnabled",database.getConfig().isPaginationEnabled());
         scopes.put("schema", new MustacheSchema(database.getSchema(), ""));
         scopes.put("catalog", new MustacheCatalog(database.getCatalog(), ""));
@@ -99,7 +99,7 @@ public class HtmlMainIndexPage extends HtmlFormatter {
         mw.write("main.html", "index.html", "main.js");
     }
 
-    private String getDatabaseDescription(Database db) {
+    private String getDatabaseName(Database db) {
         StringBuilder description = new StringBuilder();
 
         description.append(db.getName());
@@ -112,10 +112,5 @@ public class HtmlMainIndexPage extends HtmlFormatter {
         }
 
         return description.toString();
-    }
-
-    @Override
-    protected boolean isMainIndex() {
-        return true;
     }
 }

--- a/src/main/resources/layout/main.html
+++ b/src/main/resources/layout/main.html
@@ -1,10 +1,27 @@
       <!-- Content Header (Page header) -->
       <section class="content-header">
         <h1>Tables</h1></br>
-		<div class="callout callout-info"> 		
-			<h4>SchemaSpy Analysis of {{databaseName}}</h4>
-			<p>Generated on {{database.connectTime}}</p>
+		<div class="row">
+			<div class="col-md-12">
+				<div class="callout callout-info">
+					<h4>SchemaSpy Analysis of {{databaseName}}</h4>
+					<p>Generated on {{database.connectTime}}</p>
+				</div>
+			</div>
 		</div>
+
+		{{#description}}
+		<div class="row">
+		  <div class="col-md-12">
+			<div class="box box-solid">
+			  <div class="box-body">
+				  <p>{{{description}}}</p>
+			  </div>
+			</div>
+		  </div>
+		</div>
+		{{/description}}
+
         <a href="{{databaseName}}.xml" title="XML Representation">XML Representation</a></br>
 		<a href="insertionOrder.txt" title="Useful for loading data into a database">Insertion Order</a>
         <a href="deletionOrder.txt" title="Useful for purging data from a database">Deletion Order</a>	


### PR DESCRIPTION
This pull request is covering backward compatibility with SchemaSpy 5.0.x after information provided after `-desc` parameter will be visible on main page fix #149

`-desc "<b>Connection details:</b></br><b>Host/Port: </b>127.0.0.1:1433</br><b>DBName: </b>Librrary</br>"`

![schemaspy-description](https://user-images.githubusercontent.com/19885116/31038670-6d2b969c-a578-11e7-9957-5895178e6293.PNG)
