### PR TITLE
Fix some sonar warnings, consistent use of try-with-resource for SQL

### DIFF
--- a/src/main/java/org/schemaspy/Config.java
+++ b/src/main/java/org/schemaspy/Config.java
@@ -1446,7 +1446,6 @@ public final class Config {
         }
 
         Properties props = asProperties(bundle);
-        bundle = null;
         String saveLoadedFrom = dbPropertiesLoadedFrom; // keep original thru recursion
 
         // bring in key/values pointed to by the include directive
@@ -1577,7 +1576,7 @@ public final class Config {
             return null;
         }
         options.remove(paramIndex);
-        String param = options.get(paramIndex).toString();
+        String param = options.get(paramIndex);
         options.remove(paramIndex);
         return param;
     }

--- a/src/main/java/org/schemaspy/DbAnalyzer.java
+++ b/src/main/java/org/schemaspy/DbAnalyzer.java
@@ -193,7 +193,7 @@ public class DbAnalyzer {
         List<Table> withoutIndexes = new ArrayList<Table>();
 
         for (Table table : tables) {
-            if (table.getIndexes().size() == 0 && !table.isView() && !table.isLogical())
+            if (table.getIndexes().isEmpty() && !table.isView() && !table.isLogical())
                 withoutIndexes.add(table);
         }
 

--- a/src/main/java/org/schemaspy/service/DatabaseService.java
+++ b/src/main/java/org/schemaspy/service/DatabaseService.java
@@ -84,42 +84,31 @@ public class DatabaseService {
    private void initCatalogs(Config config, Database db, ProgressListener listener) throws SQLException {
 
             String sql = Config.getInstance().getDbProperties().getProperty("selectCatalogsSql");
-            PreparedStatement stmt = null;
-			ResultSet rs =  null;
+
             if (sql != null && db.getCatalog() != null) {
-                try {
-                stmt = sqlService.prepareStatement(sql,db,null);
-                rs = stmt.executeQuery();
-                    while (rs.next()) {
+                try (PreparedStatement stmt = sqlService.prepareStatement(sql, db, null);
+                     ResultSet rs = stmt.executeQuery();) {
+                    if (rs.next()) {
                          db.getCatalog().setComment(rs.getString("catalog_comment"));
-                         break;
                     }
                 } catch (SQLException sqlException) {
                     //db.getSchema().setComment(null);
-                } finally {// 
-                    stmt.close();
-                  	rs.close();
                 }
             }
     }
 
     private void initSchemas(Config config, Database db, ProgressListener listener) throws SQLException {
     	  String sql = Config.getInstance().getDbProperties().getProperty("selectSchemasSql");
-          PreparedStatement stmt = null;
-			ResultSet rs =  null;
+
           if (sql != null &&  db.getSchema() != null) {
-              try {
-              stmt = sqlService.prepareStatement(sql,db,null);
-              rs = stmt.executeQuery();
-                  while (rs.next()) {
+              try (PreparedStatement stmt = sqlService.prepareStatement(sql, db, null);
+                   ResultSet rs = stmt.executeQuery()) {
+
+                  if (rs.next()) {
                        db.getSchema().setComment(rs.getString("schema_comment"));
-                       break;
                   }
               } catch (SQLException sqlException) {
                   //db.getSchema().setComment(null);
-              } finally {
-                stmt.close();
-              	rs.close();
               }
           }
     }
@@ -418,15 +407,14 @@ public class DatabaseService {
         String queryName = forTables ? "selectTablesSql" : "selectViewsSql";
         String sql = config.getDbProperties().getProperty(queryName);
         List<BasicTableMeta> basics = new ArrayList<BasicTableMeta>();
-        ResultSet rs = null;
+
 
         if (sql != null) {
             String clazz = forTables ? "table" : "view";
-            PreparedStatement stmt = null;
 
-            try {
-                stmt = sqlService.prepareStatement(sql,db, null);
-                rs = stmt.executeQuery();
+
+            try (PreparedStatement stmt = sqlService.prepareStatement(sql, db, null);
+                 ResultSet rs = stmt.executeQuery()) {
 
                 while (rs.next()) {
                     String name = rs.getString(clazz + "_name");
@@ -447,20 +435,15 @@ public class DatabaseService {
                 if (msg != null) {
                     logger.warning(msg);
                 }
-            } finally {
-                if (rs != null)
-                    rs.close();
-                if (stmt != null)
-                    stmt.close();
             }
         }
 
         if (basics.isEmpty()) {
-            rs = metadata.getTables(null, db.getSchema().getName(), "%", types);
-
-            try {
+            String lastTableName = null;
+            try (ResultSet rs = metadata.getTables(null, db.getSchema().getName(), "%", types)){
                 while (rs.next()) {
                     String name = rs.getString("TABLE_NAME");
+                    lastTableName = name;
                     String type = rs.getString("TABLE_TYPE");
                     String cat = rs.getString("TABLE_CAT");
                     String schem = rs.getString("TABLE_SCHEM");
@@ -474,12 +457,9 @@ public class DatabaseService {
 
                 System.out.flush();
                 System.err.println();
-                System.err.println("Ignoring view " + rs.getString("TABLE_NAME") + " due to exception:");
+                System.err.println("Ignoring view " + lastTableName + " due to exception:");
                 exc.printStackTrace();
                 System.err.println("Continuing analysis.");
-            } finally {
-                if (rs != null)
-                    rs.close();
             }
         }
 
@@ -503,12 +483,8 @@ public class DatabaseService {
     private void initCheckConstraints(Config config, Database db, ProgressListener listener) throws SQLException {
         String sql = config.getDbProperties().getProperty("selectCheckConstraintsSql");
         if (sql != null) {
-            PreparedStatement stmt = null;
-            ResultSet rs = null;
-
-            try {
-                stmt = sqlService.prepareStatement(sql, db,null);
-                rs = stmt.executeQuery();
+            try (PreparedStatement stmt = sqlService.prepareStatement(sql, db,null);
+                 ResultSet rs = stmt.executeQuery()) {
 
                 while (rs.next()) {
                     String tableName = rs.getString("table_name");
@@ -522,11 +498,6 @@ public class DatabaseService {
                 if (msg != null) {
                     logger.warning(msg);
                 }
-            } finally {
-                if (rs != null)
-                    rs.close();
-                if (stmt != null)
-                    stmt.close();
             }
         }
     }
@@ -534,12 +505,9 @@ public class DatabaseService {
     private void initColumnTypes(Config config, Database db, ProgressListener listener) throws SQLException {
         String sql = config.getDbProperties().getProperty("selectColumnTypesSql");
         if (sql != null) {
-            PreparedStatement stmt = null;
-            ResultSet rs = null;
 
-            try {
-                stmt = sqlService.prepareStatement(sql,db, null);
-                rs = stmt.executeQuery();
+            try (PreparedStatement stmt = sqlService.prepareStatement(sql, db, null);
+                 ResultSet rs = stmt.executeQuery()) {
 
                 while (rs.next()) {
                     String tableName = rs.getString("table_name");
@@ -559,11 +527,6 @@ public class DatabaseService {
                 if (msg != null) {
                     logger.warning(msg);
                 }
-            } finally {
-                if (rs != null)
-                    rs.close();
-                if (stmt != null)
-                    stmt.close();
             }
         }
     }
@@ -571,12 +534,9 @@ public class DatabaseService {
     private void initTableIds(Config config, Database db) throws SQLException {
         String sql = config.getDbProperties().getProperty("selectTableIdsSql");
         if (sql != null) {
-            PreparedStatement stmt = null;
-            ResultSet rs = null;
 
-            try {
-                stmt = sqlService.prepareStatement(sql,db, null);
-                rs = stmt.executeQuery();
+            try (PreparedStatement stmt = sqlService.prepareStatement(sql, db, null);
+                 ResultSet rs = stmt.executeQuery()) {
 
                 while (rs.next()) {
                     String tableName = rs.getString("table_name");
@@ -588,11 +548,6 @@ public class DatabaseService {
                 System.err.println();
                 System.err.println(sql);
                 throw sqlException;
-            } finally {
-                if (rs != null)
-                    rs.close();
-                if (stmt != null)
-                    stmt.close();
             }
         }
     }
@@ -600,12 +555,9 @@ public class DatabaseService {
     private void initIndexIds(Config config, Database db) throws SQLException {
         String sql = config.getDbProperties().getProperty("selectIndexIdsSql");
         if (sql != null) {
-            PreparedStatement stmt = null;
-            ResultSet rs = null;
 
-            try {
-                stmt = sqlService.prepareStatement(sql,db, null);
-                rs = stmt.executeQuery();
+            try (PreparedStatement stmt = sqlService.prepareStatement(sql, db, null);
+                 ResultSet rs = stmt.executeQuery()) {
 
                 while (rs.next()) {
                     String tableName = rs.getString("table_name");
@@ -620,11 +572,6 @@ public class DatabaseService {
                 System.err.println();
                 System.err.println(sql);
                 throw sqlException;
-            } finally {
-                if (rs != null)
-                    rs.close();
-                if (stmt != null)
-                    stmt.close();
             }
         }
     }
@@ -639,12 +586,9 @@ public class DatabaseService {
     private void initTableComments(Config config, Database db, ProgressListener listener) throws SQLException {
         String sql = config.getDbProperties().getProperty("selectTableCommentsSql");
         if (sql != null) {
-            PreparedStatement stmt = null;
-            ResultSet rs = null;
 
-            try {
-                stmt = sqlService.prepareStatement(sql,db, null);
-                rs = stmt.executeQuery();
+            try (PreparedStatement stmt = sqlService.prepareStatement(sql, db, null);
+                 ResultSet rs = stmt.executeQuery()) {
 
                 while (rs.next()) {
                     String tableName = rs.getString("table_name");
@@ -658,11 +602,6 @@ public class DatabaseService {
                 if (msg != null) {
                     logger.warning(msg);
                 }
-            } finally {
-                if (rs != null)
-                    rs.close();
-                if (stmt != null)
-                    stmt.close();
             }
         }
     }
@@ -675,12 +614,9 @@ public class DatabaseService {
     private void initViewComments(Config config, Database db, ProgressListener listener) throws SQLException {
         String sql = config.getDbProperties().getProperty("selectViewCommentsSql");
         if (sql != null) {
-            PreparedStatement stmt = null;
-            ResultSet rs = null;
 
-            try {
-                stmt = sqlService.prepareStatement(sql,db, null);
-                rs = stmt.executeQuery();
+            try (PreparedStatement stmt = sqlService.prepareStatement(sql, db, null);
+                 ResultSet rs = stmt.executeQuery()) {
 
                 while (rs.next()) {
                     String viewName = rs.getString("view_name");
@@ -697,11 +633,6 @@ public class DatabaseService {
                 if (msg != null) {
                     logger.warning(msg);
                 }
-            } finally {
-                if (rs != null)
-                    rs.close();
-                if (stmt != null)
-                    stmt.close();
             }
         }
     }
@@ -716,12 +647,9 @@ public class DatabaseService {
     private void initTableColumnComments(Config config, Database db, ProgressListener listener) throws SQLException {
         String sql = config.getDbProperties().getProperty("selectColumnCommentsSql");
         if (sql != null) {
-            PreparedStatement stmt = null;
-            ResultSet rs = null;
 
-            try {
-                stmt = sqlService.prepareStatement(sql,db, null);
-                rs = stmt.executeQuery();
+            try (PreparedStatement stmt = sqlService.prepareStatement(sql, db, null);
+                 ResultSet rs = stmt.executeQuery()) {
 
                 while (rs.next()) {
                     String tableName = rs.getString("table_name");
@@ -738,11 +666,6 @@ public class DatabaseService {
                 if (msg != null) {
                     logger.warning(msg);
                 }
-            } finally {
-                if (rs != null)
-                    rs.close();
-                if (stmt != null)
-                    stmt.close();
             }
         }
     }
@@ -755,12 +678,9 @@ public class DatabaseService {
     private void initViewColumnComments(Config config, Database db, ProgressListener listener) throws SQLException {
         String sql = config.getDbProperties().getProperty("selectViewColumnCommentsSql");
         if (sql != null) {
-            PreparedStatement stmt = null;
-            ResultSet rs = null;
 
-            try {
-                stmt = sqlService.prepareStatement(sql,db, null);
-                rs = stmt.executeQuery();
+            try (PreparedStatement stmt = sqlService.prepareStatement(sql, db, null);
+                 ResultSet rs = stmt.executeQuery()) {
 
                 while (rs.next()) {
                     String viewName = rs.getString("view_name");
@@ -780,11 +700,6 @@ public class DatabaseService {
                 if (msg != null) {
                     logger.warning(msg);
                 }
-            } finally {
-                if (rs != null)
-                    rs.close();
-                if (stmt != null)
-                    stmt.close();
             }
         }
     }
@@ -798,12 +713,9 @@ public class DatabaseService {
         String sql = config.getDbProperties().getProperty("selectRoutinesSql");
 
         if (sql != null) {
-            PreparedStatement stmt = null;
-            ResultSet rs = null;
 
-            try {
-                stmt = sqlService.prepareStatement(sql,db, null);
-                rs = stmt.executeQuery();
+            try (PreparedStatement stmt = sqlService.prepareStatement(sql, db, null);
+                 ResultSet rs = stmt.executeQuery()) {
 
                 while (rs.next()) {
                     String routineName = rs.getString("routine_name");
@@ -827,25 +739,15 @@ public class DatabaseService {
                 if (msg != null) {
                     logger.warning(msg);
                 }
-            } finally {
-                if (rs != null)
-                    rs.close();
-                if (stmt != null)
-                    stmt.close();
-                rs = null;
-                stmt = null;
             }
         }
 
         sql = config.getDbProperties().getProperty("selectRoutineParametersSql");
 
         if (sql != null) {
-            PreparedStatement stmt = null;
-            ResultSet rs = null;
 
-            try {
-                stmt = sqlService.prepareStatement(sql,db, null);
-                rs = stmt.executeQuery();
+            try (PreparedStatement stmt = sqlService.prepareStatement(sql, db, null);
+                 ResultSet rs = stmt.executeQuery()) {
 
                 while (rs.next()) {
                     String routineName = rs.getString("specific_name");
@@ -867,11 +769,6 @@ public class DatabaseService {
                 if (msg != null) {
                     logger.warning(msg);
                 }
-            } finally {
-                if (rs != null)
-                    rs.close();
-                if (stmt != null)
-                    stmt.close();
             }
         }
     }

--- a/src/main/java/org/schemaspy/service/DatabaseService.java
+++ b/src/main/java/org/schemaspy/service/DatabaseService.java
@@ -92,7 +92,8 @@ public class DatabaseService {
                          db.getCatalog().setComment(rs.getString("catalog_comment"));
                     }
                 } catch (SQLException sqlException) {
-                    //db.getSchema().setComment(null);
+                    logger.severe(sql);
+                    throw sqlException;
                 }
             }
     }
@@ -108,7 +109,8 @@ public class DatabaseService {
                        db.getSchema().setComment(rs.getString("schema_comment"));
                   }
               } catch (SQLException sqlException) {
-                  //db.getSchema().setComment(null);
+                  logger.severe(sql);
+                  throw sqlException;
               }
           }
     }

--- a/src/main/java/org/schemaspy/service/SqlService.java
+++ b/src/main/java/org/schemaspy/service/SqlService.java
@@ -96,17 +96,12 @@ public class SqlService {
         if (fineEnabled)
             logger.fine(sqlBuf + " " + sqlParams);
 
-        PreparedStatement stmt = connection.prepareStatement(sqlBuf.toString());
-        try {
+        try (PreparedStatement stmt = connection.prepareStatement(sqlBuf.toString())) {
             for (int i = 0; i < sqlParams.size(); ++i) {
-                stmt.setString(i + 1, sqlParams.get(i).toString());
+                stmt.setString(i + 1, sqlParams.get(i));
             }
-        } catch (SQLException exc) {
-            stmt.close();
-            throw exc;
+            return stmt;
         }
-
-        return stmt;
     }
 
     /**

--- a/src/main/java/org/schemaspy/service/SqlService.java
+++ b/src/main/java/org/schemaspy/service/SqlService.java
@@ -96,12 +96,17 @@ public class SqlService {
         if (fineEnabled)
             logger.fine(sqlBuf + " " + sqlParams);
 
-        try (PreparedStatement stmt = connection.prepareStatement(sqlBuf.toString())) {
+        PreparedStatement stmt = connection.prepareStatement(sqlBuf.toString());
+        try {
             for (int i = 0; i < sqlParams.size(); ++i) {
                 stmt.setString(i + 1, sqlParams.get(i));
             }
-            return stmt;
+        } catch (SQLException exc) {
+            stmt.close();
+            throw exc;
         }
+
+        return stmt;
     }
 
     /**

--- a/src/main/java/org/schemaspy/service/ViewService.java
+++ b/src/main/java/org/schemaspy/service/ViewService.java
@@ -38,12 +38,10 @@ public class ViewService {
             return null;
         }
 
-        PreparedStatement stmt = null;
-        ResultSet rs = null;
         StringBuilder viewDefinition = new StringBuilder();
-        try {
-            stmt = sqlService.prepareStatement(selectViewSql,db, view.getName());
-            rs = stmt.executeQuery();
+        try (PreparedStatement stmt = sqlService.prepareStatement(selectViewSql, db, view.getName());
+             ResultSet rs = stmt.executeQuery()) {
+
             while (rs.next()) {
                 try {
                     viewDefinition.append(rs.getString("view_definition"));
@@ -55,11 +53,6 @@ public class ViewService {
         } catch (SQLException sqlException) {
             LOGGER.log(Level.SEVERE, selectViewSql);
             throw sqlException;
-        } finally {
-            if (rs != null)
-                rs.close();
-            if (stmt != null)
-                stmt.close();
         }
     }
 }

--- a/src/main/java/org/schemaspy/util/DiagramUtil.java
+++ b/src/main/java/org/schemaspy/util/DiagramUtil.java
@@ -54,14 +54,14 @@ public class DiagramUtil {
 
     public static Object diagramExists(List<MustacheTableDiagram> diagrams) {
         Object exists = null;
-        if  (diagrams.size() > 0) {
+        if  (!diagrams.isEmpty()) {
             exists = new Object();
         }
         return exists;
     }
 
     public static void markFirstAsActive(List<MustacheTableDiagram> diagrams) {
-        if (diagrams != null && diagrams.size() > 0) {
+        if (diagrams != null && !diagrams.isEmpty()) {
             MustacheTableDiagram diagram = diagrams.get(0);
             if (diagram != null) {
                 diagram.setActive(true);

--- a/src/main/java/org/schemaspy/util/Markdown.java
+++ b/src/main/java/org/schemaspy/util/Markdown.java
@@ -48,7 +48,7 @@ public class Markdown {
             links.add(m.group(1));
         }
 
-        if (links.size() > 0) {
+        if (!links.isEmpty()) {
             text = text + newLine + newLine;
         }
 

--- a/src/main/java/org/schemaspy/view/XmlTableFormatter.java
+++ b/src/main/java/org/schemaspy/view/XmlTableFormatter.java
@@ -216,7 +216,7 @@ public class XmlTableFormatter {
                 tableNode.appendChild(constraintNode);
 
                 DOMUtil.appendAttribute(constraintNode, "name", name);
-                DOMUtil.appendAttribute(constraintNode, "constraint", constraints.get(name).toString());
+                DOMUtil.appendAttribute(constraintNode, "constraint", constraints.get(name));
             }
         }
     }


### PR DESCRIPTION
Fix the following Sonar issues to try and get the quality up a little bit (and learn the codebase in the process)

* Removed a dead store (1 occurrence)
* Use isEmpty() to check whether the collection is empty or not. (4 occurrences)
* ...  returns a string, there's no need to call "toString()". (6 occurrences)
* Use try-with-resources for Statements and ResultSets. There were a few different patterns to how these were being closed - sometimes null checked without try-catch around the close, sometimes in the wrong order (statement then resultset), sometimes they were not null checked, and sometimes with a stacktrace being printed.
* There were a couple of `while ... break` loops that executed at most one time. Changed these to `if` blocks. This was an Intellij warning.

I debated implementing a closeQuietly method (Spring provides one, but I didn't want to introduce a dependency on Spring that deep into the project), and erred on the side of using built-in functionality instead.