### PR TITLE
#162 - Add pagination

### DIFF
--- a/src/main/java/org/schemaspy/view/HtmlColumnsPage.java
+++ b/src/main/java/org/schemaspy/view/HtmlColumnsPage.java
@@ -147,6 +147,7 @@ public class HtmlColumnsPage extends HtmlFormatter {
 
         HashMap<String, Object> scopes = new HashMap<String, Object>();
         scopes.put("columns", tableColumns);
+        scopes.put("paginationEnabled",database.getConfig().isPaginationEnabled());
 
         MustacheWriter mw = new MustacheWriter(outputDir, scopes, getPathToRoot(), database.getName(), false);
         mw.write("column.html", "columns.html", "column.js");

--- a/src/main/java/org/schemaspy/view/HtmlConstraintsPage.java
+++ b/src/main/java/org/schemaspy/view/HtmlConstraintsPage.java
@@ -56,6 +56,7 @@ public class HtmlConstraintsPage extends HtmlFormatter {
         HashMap<String, Object> scopes = new HashMap<String, Object>();
         scopes.put("constraints", constraints);
         scopes.put("tables", tables);
+        scopes.put("paginationEnabled",database.getConfig().isPaginationEnabled());
 
         MustacheWriter mw = new MustacheWriter( outputDir, scopes, getPathToRoot(), database.getName(), false);
         mw.write("constraint.html", "constraints.html", "constraint.js");

--- a/src/main/resources/layout/column.html
+++ b/src/main/resources/layout/column.html
@@ -45,6 +45,6 @@
       </section>
 	  <script>
           var config = {
-              paggination: {{paginationEnabled}}
+	          pagination: {{paginationEnabled}}
           }
 	  </script>

--- a/src/main/resources/layout/column.html
+++ b/src/main/resources/layout/column.html
@@ -43,3 +43,8 @@
 			</div>
 		</div>	
       </section>
+	  <script>
+          var config = {
+              paggination: {{paginationEnabled}}
+          }
+	  </script>

--- a/src/main/resources/layout/column.js
+++ b/src/main/resources/layout/column.js
@@ -18,7 +18,8 @@ $(document).ready(function() {
     var table = $('#column_table').DataTable( {
         lengthChange: false,		
 		bSort: true,
-		bPaginate: false,
+		paging: config.paggination,
+		pageLength: 50,
 		autoWidth: true,
 		bDeferRender: true,
 		bProcessing: true,

--- a/src/main/resources/layout/column.js
+++ b/src/main/resources/layout/column.js
@@ -18,7 +18,7 @@ $(document).ready(function() {
     var table = $('#column_table').DataTable( {
         lengthChange: false,		
 		bSort: true,
-		paging: config.paggination,
+		paging: config.pagination,
 		pageLength: 50,
 		autoWidth: true,
 		bDeferRender: true,

--- a/src/main/resources/layout/constraint.html
+++ b/src/main/resources/layout/constraint.html
@@ -96,6 +96,6 @@
       </section>
 	  <script>
 	      var config = {
-		      paggination: {{paginationEnabled}}
+		      pagination: {{paginationEnabled}}
 	      }
 	  </script>

--- a/src/main/resources/layout/constraint.html
+++ b/src/main/resources/layout/constraint.html
@@ -94,3 +94,8 @@
 			</div>
 		</div>			
       </section>
+	  <script>
+	      var config = {
+		      paggination: {{paginationEnabled}}
+	      }
+	  </script>

--- a/src/main/resources/layout/constraint.js
+++ b/src/main/resources/layout/constraint.js
@@ -18,7 +18,7 @@ $(document).ready(function() {
     var table = $('#constraint_table').DataTable( {
         lengthChange: false,		
 		bSort: true,
-		paging: config.paggination,
+		paging: config.pagination,
 		pageLength: 50,
 		autoWidth: true,
 		bDeferRender: true,

--- a/src/main/resources/layout/constraint.js
+++ b/src/main/resources/layout/constraint.js
@@ -18,7 +18,8 @@ $(document).ready(function() {
     var table = $('#constraint_table').DataTable( {
         lengthChange: false,		
 		bSort: true,
-		bPaginate: false,
+		paging: config.paggination,
+		pageLength: 50,
 		autoWidth: true,
 		bDeferRender: true,
 		bProcessing: true,

--- a/src/main/resources/layout/main.html
+++ b/src/main/resources/layout/main.html
@@ -156,6 +156,6 @@
       <!-- /.content -->
 	  <script>
           var config = {
-              paggination: {{paginationEnabled}}
+	          pagination: {{paginationEnabled}}
           }
 	  </script>

--- a/src/main/resources/layout/main.js
+++ b/src/main/resources/layout/main.js
@@ -17,7 +17,7 @@ $(document).ready(function() {
 	var activeObject;
     var table = $('#database_objects').DataTable( {
         lengthChange: false,
-        paging: config.paggination,
+        paging: config.pagination,
 		pageLength: 50,
 		buttons: [
 						{


### PR DESCRIPTION
#162 - Add pagination to both the column and constraint pages

Follow the setting used on the main table listing page

Tested on a database with ~800 tables, ~9,000 columns, and ~600 constraints.

I do wonder if adding pagination controls to the top in addition to the bottom would be helpful. See https://datatables.net/examples/advanced_init/dom_multiple_elements.html for an example

Initial rendering of the column page is still slow due to how datatables works. It still has to render all of the rows and then hide them. So, this might not fully solve #162 