### PR TITLE
Add tests for HtmlFormatter, fix URL encoding issue in maps

### DIFF
--- a/src/main/java/org/schemaspy/view/DotNode.java
+++ b/src/main/java/org/schemaspy/view/DotNode.java
@@ -18,7 +18,6 @@
  */
 package org.schemaspy.view;
 
-import org.apache.commons.io.FilenameUtils;
 import org.schemaspy.Config;
 import org.schemaspy.model.Table;
 import org.schemaspy.model.TableColumn;
@@ -28,7 +27,6 @@ import java.awt.*;
 import java.awt.font.FontRenderContext;
 import java.awt.geom.AffineTransform;
 import java.io.File;
-import java.net.URL;
 import java.text.NumberFormat;
 import java.util.HashSet;
 import java.util.List;
@@ -203,8 +201,8 @@ public class DotNode {
 
         buf.append("    </TABLE>>" + lineSeparator);
         if (!table.isRemote() || Config.getInstance().isOneOfMultipleSchemas())
-            buf.append("    URL=\"" + path + HtmlFormatter.urlEncode(tableName) + ".html\"" + lineSeparator);
-        buf.append("    tooltip=\"" + HtmlFormatter.urlEncode(fqTableName) + "\"" + lineSeparator);
+            buf.append("    URL=\"" + path + HtmlFormatter.urlEncodeLink(tableName) + ".html\"" + lineSeparator);
+        buf.append("    tooltip=\"" + HtmlFormatter.escapeHtml(fqTableName) + "\"" + lineSeparator);
         buf.append("  ];");
 
         return buf.toString();

--- a/src/main/java/org/schemaspy/view/HtmlFormatter.java
+++ b/src/main/java/org/schemaspy/view/HtmlFormatter.java
@@ -19,6 +19,7 @@
 package org.schemaspy.view;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.HashSet;
@@ -26,6 +27,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import com.github.mustachejava.MustacheVisitor;
+import com.github.mustachejava.util.HtmlEscaper;
 import org.schemaspy.Config;
 import org.schemaspy.Revision;
 import org.schemaspy.model.Database;
@@ -36,6 +39,7 @@ import org.schemaspy.util.HtmlEncoder;
 import org.schemaspy.util.LineWriter;
 
 public class HtmlFormatter {
+    private static final Logger logger = Logger.getLogger(HtmlFormatter.class.getName());
     protected final boolean encodeComments = Config.getInstance().isEncodeCommentsEnabled();
     private   final boolean isMetered = Config.getInstance().isMeterEnabled();
     protected final boolean displayNumRows = Config.getInstance().isNumRowsEnabled();
@@ -59,16 +63,21 @@ public class HtmlFormatter {
 
 
     /**
-     * Encode the specified string
+     * HTML escape the specified string
      *
      * @param string
      * @return
      */
-    static String urlEncode(String string) {
+    static String escapeHtml(String string) {
+        StringWriter writer = new StringWriter();
+        HtmlEscaper.escape(string, writer);
+        return writer.toString();
+    }
+
+    static String urlEncodeLink(String string) {
         try {
-            return URLEncoder.encode(string, Config.DOT_CHARSET);
+            return URLEncoder.encode(string, Config.DOT_CHARSET).replace("+","%20");
         } catch (UnsupportedEncodingException e) {
-            Logger logger = Logger.getLogger(HtmlFormatter.class.getName());
             logger.info("Error trying to urlEncode string [" + string + "] with encoding [" + Config.DOT_CHARSET + "]");
             return string;
         }

--- a/src/test/java/org/schemaspy/view/HtmlFormatterTest.java
+++ b/src/test/java/org/schemaspy/view/HtmlFormatterTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class HtmlFormatterTest {
 
     @Test
-    public void urlEncode() {
+    public void escapeHtml() {
         assertThat(HtmlFormatter.escapeHtml("string")).isEqualTo("string");
         assertThat(HtmlFormatter.escapeHtml("string with spaces")).isEqualTo("string with spaces");
     }

--- a/src/test/java/org/schemaspy/view/HtmlFormatterTest.java
+++ b/src/test/java/org/schemaspy/view/HtmlFormatterTest.java
@@ -1,0 +1,20 @@
+package org.schemaspy.view;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HtmlFormatterTest {
+
+    @Test
+    public void urlEncode() {
+        assertThat(HtmlFormatter.escapeHtml("string")).isEqualTo("string");
+        assertThat(HtmlFormatter.escapeHtml("string with spaces")).isEqualTo("string with spaces");
+    }
+
+    @Test
+    public void urlEncodeLink() {
+        assertThat(HtmlFormatter.urlEncodeLink("string")).isEqualTo("string");
+        assertThat(HtmlFormatter.urlEncodeLink("string with spaces")).isEqualTo("string%20with%20spaces");
+    }
+}


### PR DESCRIPTION
This is a possible fix for #165 .

Tested against a SQLServer database with a table with spaces in the name, requiring the table to be wrapped in square brackets.

There is a difference between URL encoding, and escaping for HTML. The only place this code is used is in the DOT generation, and then would only affect image map generation, and maybe SVGs (if those were to be built from the DOT files). I've changed the code so that the tooltip is HTML Encoded, and the link elements are URL-escaped, with `%20` for spaces instead of `+`. Also, added tests.

I used a utility method from inside Mustache to do the escaping. There are similar utility methods in commons-lang, guava, and some Spring libraries, but none of those are on the production profile (an older commons-lang is only present in the test profile)