### PR TITLE
Don't init codemirror when there is no code element

### DIFF
--- a/src/main/resources/layout/container.html
+++ b/src/main/resources/layout/container.html
@@ -6,7 +6,7 @@
   <title>{{#table}}{{table.name}} - {{/table}}{{databaseName}} Database</title>
   <!-- Tell the browser to be responsive to screen width -->
   <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
-  <link rel="icon" type="image/png" sizes="16x16" href="favicon.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="{{rootPath}}favicon.png">
   <!-- Bootstrap 3.3.5 -->
   <link rel="stylesheet" href="{{rootPath}}bower/admin-lte/bootstrap/css/bootstrap.min.css">
   <!-- Font Awesome -->

--- a/src/main/resources/layout/tables/table.js
+++ b/src/main/resources/layout/tables/table.js
@@ -67,14 +67,18 @@ $(document).ready(function() {
 
  $(function() {
 	$("#recordNumber").digits();
- }); 
- 
- var editor = CodeMirror.fromTextArea(document.getElementById("code"), {
-	lineNumbers: true,  
-	mode: 'text/x-sql',
-    indentWithTabs: true,
-    smartIndent: true,
-    lineNumbers: true,
-    matchBrackets : true,
-    autofocus: true	
-});
+ });
+
+var codeElement = document.getElementById("code");
+var editor = null;
+if (null != codeElement) {
+	editor = CodeMirror.fromTextArea(codeElement, {
+		lineNumbers: true,
+		mode: 'text/x-sql',
+		indentWithTabs: true,
+		smartIndent: true,
+		lineNumbers: true,
+		matchBrackets: true,
+		autofocus: true
+	});
+}


### PR DESCRIPTION
The code element is not rendered for tables, just for views. So, initializing codemirror should check for the presence of the code element. This was causing errors to appear in the browser console.
Also, I noticed that the favicon was not loading on table pages. This was fixed by including the relative path to `favicon.png`, just like all of the other resources in `container.html`

Fixes #172