### PR TITLE
Escape column names in regexp sot that columns can contain charaters '{' and '}'.

### DIFF
--- a/src/main/java/org/schemaspy/DbAnalyzer.java
+++ b/src/main/java/org/schemaspy/DbAnalyzer.java
@@ -69,10 +69,10 @@ public class DbAnalyzer {
 				DatabaseObject key = entry.getKey();
 				if (columnWithoutParent.getName().compareToIgnoreCase(key.getName()) == 0
 						// if adress_id=adress_id OR shipping_adress_id like &description%_adress_id
-						|| columnWithoutParent.getName().matches("(?i).*_" + key.getName())
+						|| columnWithoutParent.getName().matches("(?i).*_" + Pattern.quote(key.getName()))
 						// if order.adressid=>adress.id. find FKs that made from %parentTablename%PKcol%
 						// if order.adress_id=>adress.id. find FKs that made from %tablename%_%PKcol%
-						|| columnWithoutParent.getName().matches("(?i)" +entry.getValue().getName() + ".*" + key.getName()) 
+						|| columnWithoutParent.getName().matches("(?i)" + Pattern.quote(entry.getValue().getName()) + ".*" + Pattern.quote(key.getName()))
 						) {
 					// check f columnTypes Or ColumnTypeNames are same.
 					if ((columnWithoutParent.getType() != null && key.getType() != null


### PR DESCRIPTION
If I use schemaspy 6.0.0-rc2 and have a table with a clumn named '{AccountBuyingKey}' I get the exception below. The following pullrequest fixes that by using Pattern.quote on all literal strings used in regex matching.


Illegal repetition near index 6
(?i).*_{AccountBuyingKey}
      ^
java.util.regex.PatternSyntaxException: Illegal repetition near index 6
(?i).*_{AccountBuyingKey}
      ^
        at java.util.regex.Pattern.error(Pattern.java:1955)
        at java.util.regex.Pattern.closure(Pattern.java:3157)
        at java.util.regex.Pattern.sequence(Pattern.java:2134)
        at java.util.regex.Pattern.expr(Pattern.java:1996)
        at java.util.regex.Pattern.compile(Pattern.java:1696)
        at java.util.regex.Pattern.<init>(Pattern.java:1351)
        at java.util.regex.Pattern.compile(Pattern.java:1028)
        at java.util.regex.Pattern.matches(Pattern.java:1133)
        at java.lang.String.matches(String.java:2121)
        at org.schemaspy.DbAnalyzer.getImpliedConstraints(DbAnalyzer.java:72)
        at org.schemaspy.SchemaAnalyzer.generateHtmlDoc(SchemaAnalyzer.java:369)