### PR TITLE
Handle when routine definition is null. (For instance in SQL Server w…

### DIFF
--- a/src/main/java/org/schemaspy/model/Routine.java
+++ b/src/main/java/org/schemaspy/model/Routine.java
@@ -60,7 +60,7 @@ public class Routine implements Comparable<Routine> {
         this.type = type;
         this.returnType = returnType;
         this.definitionLanguage = definitionLanguage;
-        this.definition = definition;
+        this.definition = coalesce(definition, "");
         this.dataAccess = dataAccess;
         this.securityType = securityType;
         this.deterministic = deterministic;
@@ -159,5 +159,9 @@ public class Routine implements Comparable<Routine> {
         if (rc == 0)
             rc = getDefinition().compareTo(other.getDefinition());
         return rc;
+    }
+
+    private <T> T coalesce(T a, T b) {
+        return a!=null ? a : b;
     }
 }

--- a/src/test/java/org/schemaspy/model/RoutineTest.java
+++ b/src/test/java/org/schemaspy/model/RoutineTest.java
@@ -1,0 +1,52 @@
+package org.schemaspy.model;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RoutineTest {
+
+    @Test
+    public void definition() throws Exception {
+        // Given
+        String procedureDefinition = "create procedure dbo.TestProcedure (@param varchar(max) AS\nselect * from dbo.TestTable";
+        Routine routine = new Routine(
+                "TestProcedure",
+                "PROCEDURE",
+                null,
+                "SQL",
+                procedureDefinition,
+                false,
+                "MODIFIES",
+                null,
+                "Comment");
+
+        // When
+        String definition = routine.getDefinition();
+
+        // Then
+        assertThat(definition).isEqualTo(procedureDefinition);
+    }
+
+    @Test
+    public void nullDefinitionIsReplacedWithEmptyString() throws Exception {
+        // Given
+        Routine routine = new Routine(
+                "testFunction",
+                "FUNCTION",
+                "varchar(10)",
+                "EXTERNAL",
+                null,
+                false,
+                "READS",
+                null,
+                "Comment");
+
+        // When
+        String definition = routine.getDefinition();
+
+        // Then
+        assertThat(definition).isEqualTo("");
+    }
+
+}


### PR DESCRIPTION
…hen a rutine is defined in an external language)

In SQL server it is not always possible to query the definition of a routine. This patch handles that case.