### PR TITLE
Move Routines support for SQLServer into new type - mssql12

### DIFF
--- a/src/main/resources/org/schemaspy/types/mssql.properties
+++ b/src/main/resources/org/schemaspy/types/mssql.properties
@@ -37,13 +37,4 @@ cmts.text AS text \
 FROM sysobjects cnstrs \
 INNER JOIN sysobjects tbls ON cnstrs.parent_obj = tbls.id \
 INNER JOIN syscomments cmts ON cmts.id = cnstrs.id \
-WHERE cnstrs.type = 'C' 
-
-selectRoutinesSql=SELECT routine_name, routine_type, data_type AS dtd_identifier, routine_body, routine_definition, is_deterministic, sql_data_access, \
-NULL AS security_type, NULL AS sql_mode, NULL AS routine_comment \
-FROM information_schema.routines \
-WHERE routine_schema = :schema
-
-selectRoutineParametersSql=SELECT specific_name, parameter_name, data_type AS dtd_identifier, parameter_mode FROM information_schema.parameters \
-WHERE specific_schema = :schema AND ordinal_position != 0 \
-ORDER BY ordinal_position
+WHERE cnstrs.type = 'C'

--- a/src/main/resources/org/schemaspy/types/mssql12-jtds-instance.properties
+++ b/src/main/resources/org/schemaspy/types/mssql12-jtds-instance.properties
@@ -1,0 +1,10 @@
+#
+# see http://schemaspy.org/dbtypes.html
+# for configuration / customization details
+#
+
+# identical to base file except for adding instance to connectionSpec
+extends=mssql12-jtds
+connectionSpec=jdbc:jtds:sqlserver://<hostOptionalPort>/<db>;instance=<instance>
+
+instance=Named instance to connect to

--- a/src/main/resources/org/schemaspy/types/mssql12-jtds.properties
+++ b/src/main/resources/org/schemaspy/types/mssql12-jtds.properties
@@ -4,7 +4,7 @@
 #
 
 # Provided by Ernest Zapata, Larry Walker and Emilian Turbatu
-description=jTDS JDBC Driver for Microsoft SQL 2000/2005 Server 
+description=jTDS JDBC Driver for Microsoft SQL Server 2012+
  
 # majority of settings are identical to jTDS: 
 extends=mssql-jtds

--- a/src/main/resources/org/schemaspy/types/mssql12-jtds.properties
+++ b/src/main/resources/org/schemaspy/types/mssql12-jtds.properties
@@ -1,0 +1,38 @@
+#
+# see http://schemaspy.org/dbtypes.html
+# for configuration / customization details
+#
+
+# Provided by Ernest Zapata, Larry Walker and Emilian Turbatu
+description=jTDS JDBC Driver for Microsoft SQL 2000/2005 Server 
+ 
+# majority of settings are identical to jTDS: 
+extends=mssql-jtds
+
+# return the table comments
+selectTableCommentsSql=SELECT OBJECT_NAME(t.object_id) AS TABLE_NAME, ex.value AS comments \
+FROM sys.tables t \
+LEFT OUTER JOIN sys.extended_properties ex \
+ON ex.major_id = t.object_id AND ex.name = 'MS_Description' AND minor_id = 0 \
+JOIN sys.schemas s ON t.schema_id = s.schema_id AND s.name = :schema \
+WHERE OBJECTPROPERTY(t.object_id, 'IsMsShipped')=0 \
+ORDER BY OBJECT_NAME(t.object_id)
+
+# return the column comments
+selectColumnCommentsSql=SELECT OBJECT_NAME(c.object_id) AS TABLE_NAME, c.name AS COLUMN_NAME, ex.value AS comments \
+FROM sys.columns c \
+LEFT OUTER JOIN sys.extended_properties ex \
+ON ex.major_id = c.object_id AND ex.minor_id = c.column_id AND ex.name = 'MS_Description' \
+JOIN sys.tables t ON t.object_id = c.object_id \
+JOIN sys.schemas s ON t.schema_id = s.schema_id AND s.name = :schema \
+WHERE OBJECTPROPERTY(c.object_id, 'IsMsShipped')=0 \
+ORDER BY OBJECT_NAME(c.object_id), c.column_id 
+
+selectRoutinesSql=SELECT routine_name, routine_type, data_type AS dtd_identifier, routine_body, routine_definition, is_deterministic, sql_data_access, \
+NULL AS security_type, NULL AS sql_mode, NULL AS routine_comment \
+FROM information_schema.routines \
+WHERE routine_schema = :schema
+
+selectRoutineParametersSql=SELECT specific_name, parameter_name, data_type AS dtd_identifier, parameter_mode FROM information_schema.parameters \
+WHERE specific_schema = :schema AND ordinal_position != 0 \
+ORDER BY ordinal_position

--- a/src/main/resources/org/schemaspy/types/mssql12-jtds.properties
+++ b/src/main/resources/org/schemaspy/types/mssql12-jtds.properties
@@ -3,30 +3,10 @@
 # for configuration / customization details
 #
 
-# Provided by Ernest Zapata, Larry Walker and Emilian Turbatu
 description=jTDS JDBC Driver for Microsoft SQL Server 2012+
  
 # majority of settings are identical to jTDS: 
-extends=mssql-jtds
-
-# return the table comments
-selectTableCommentsSql=SELECT OBJECT_NAME(t.object_id) AS TABLE_NAME, ex.value AS comments \
-FROM sys.tables t \
-LEFT OUTER JOIN sys.extended_properties ex \
-ON ex.major_id = t.object_id AND ex.name = 'MS_Description' AND minor_id = 0 \
-JOIN sys.schemas s ON t.schema_id = s.schema_id AND s.name = :schema \
-WHERE OBJECTPROPERTY(t.object_id, 'IsMsShipped')=0 \
-ORDER BY OBJECT_NAME(t.object_id)
-
-# return the column comments
-selectColumnCommentsSql=SELECT OBJECT_NAME(c.object_id) AS TABLE_NAME, c.name AS COLUMN_NAME, ex.value AS comments \
-FROM sys.columns c \
-LEFT OUTER JOIN sys.extended_properties ex \
-ON ex.major_id = c.object_id AND ex.minor_id = c.column_id AND ex.name = 'MS_Description' \
-JOIN sys.tables t ON t.object_id = c.object_id \
-JOIN sys.schemas s ON t.schema_id = s.schema_id AND s.name = :schema \
-WHERE OBJECTPROPERTY(c.object_id, 'IsMsShipped')=0 \
-ORDER BY OBJECT_NAME(c.object_id), c.column_id 
+extends=mssql05-jtds
 
 selectRoutinesSql=SELECT routine_name, routine_type, data_type AS dtd_identifier, routine_body, routine_definition, is_deterministic, sql_data_access, \
 NULL AS security_type, NULL AS sql_mode, NULL AS routine_comment \

--- a/src/main/resources/org/schemaspy/types/mssql12.properties
+++ b/src/main/resources/org/schemaspy/types/mssql12.properties
@@ -30,3 +30,12 @@ selectTableCommentsSql=SELECT i_s.TABLE_NAME, CAST(s.value AS VARCHAR(MAX)) AS c
 # return table_name, column_name, comments for a specific :schema
 # SQL provided by Ernest Zapata & Erik Putrycz 
 selectColumnCommentsSql=SELECT OBJECT_NAME(c.object_id) AS TABLE_NAME, c.name AS COLUMN_NAME, CAST(ex.value AS varchar(MAX)) AS comments FROM sys.columns c LEFT OUTER JOIN sys.extended_properties ex ON ex.major_id \= c.object_id AND ex.minor_id \= c.column_id AND ex.name \= 'MS_Description' WHERE OBJECTPROPERTY(c.object_id, 'IsMsShipped')\=0 ORDER BY OBJECT_NAME(c.object_id), c.column_id
+
+selectRoutinesSql=SELECT routine_name, routine_type, data_type AS dtd_identifier, routine_body, routine_definition, is_deterministic, sql_data_access, \
+NULL AS security_type, NULL AS sql_mode, NULL AS routine_comment \
+FROM information_schema.routines \
+WHERE routine_schema = :schema
+
+selectRoutineParametersSql=SELECT specific_name, parameter_name, data_type AS dtd_identifier, parameter_mode FROM information_schema.parameters \
+WHERE specific_schema = :schema AND ordinal_position != 0 \
+ORDER BY ordinal_position

--- a/src/main/resources/org/schemaspy/types/mssql12.properties
+++ b/src/main/resources/org/schemaspy/types/mssql12.properties
@@ -4,7 +4,7 @@
 #
 
 # Provided by Craig Boland
-description=Microsoft SQL Server 2005+
+description=Microsoft SQL Server 2012+
 
 # some details in mssql.properties:
 extends=mssql

--- a/src/main/resources/org/schemaspy/types/mssql12.properties
+++ b/src/main/resources/org/schemaspy/types/mssql12.properties
@@ -3,33 +3,10 @@
 # for configuration / customization details
 #
 
-# Provided by Craig Boland
 description=Microsoft SQL Server 2012+
 
 # some details in mssql.properties:
-extends=mssql
-connectionSpec=jdbc:sqlserver://<hostOptionalPort>;databaseName=<db>
-host=host where database resides with optional port
-port=port database is listening on
-db=database name
-
-driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
-
-# path to the sql server drivers inside the schemaspy.jar
-# Use -dp to override.
-driverPath=/org/schemaspy/drivers/sqljdbc4-3.0.jar
-
-# querying database metadata isn't thread safe with this driver.
-dbThreads=1
-
-# return table_name, comments for current schema
-# SQL provided by Stefano Santoro
-selectTableCommentsSql=SELECT i_s.TABLE_NAME, CAST(s.value AS VARCHAR(MAX)) AS comments FROM INFORMATION_SCHEMA.Tables i_s INNER JOIN sys.extended_properties s ON s.major_id \= OBJECT_ID(i_s.table_catalog + '..' + i_s.table_name) WHERE s.class \= 1 AND s.name \= 'MS_Description' AND s.minor_id \= 0
-
-# reference: http://databases.aspfaq.com/schema-tutorials/schema-how-do-i-show-the-description-property-of-a-column.html
-# return table_name, column_name, comments for a specific :schema
-# SQL provided by Ernest Zapata & Erik Putrycz 
-selectColumnCommentsSql=SELECT OBJECT_NAME(c.object_id) AS TABLE_NAME, c.name AS COLUMN_NAME, CAST(ex.value AS varchar(MAX)) AS comments FROM sys.columns c LEFT OUTER JOIN sys.extended_properties ex ON ex.major_id \= c.object_id AND ex.minor_id \= c.column_id AND ex.name \= 'MS_Description' WHERE OBJECTPROPERTY(c.object_id, 'IsMsShipped')\=0 ORDER BY OBJECT_NAME(c.object_id), c.column_id
+extends=mssql05
 
 selectRoutinesSql=SELECT routine_name, routine_type, data_type AS dtd_identifier, routine_body, routine_definition, is_deterministic, sql_data_access, \
 NULL AS security_type, NULL AS sql_mode, NULL AS routine_comment \


### PR DESCRIPTION
Per our discussion in #182, this moves the support for querying routines to a new database type - mssql12.

This also adds support for routines to the JDTS driver

* mssql12 extends mssql05 extends mssql
* mssql12-jtds extends mssql05-jtds extends mssql-jtds
* mssql12-jtds-instance extends mssql05-jtds-instance extends mssql-jtds-instance