### PR TITLE
Clean up Sonar warnings around File deletion

### DIFF
--- a/src/main/java/org/schemaspy/cli/PropertyFileDefaultProvider.java
+++ b/src/main/java/org/schemaspy/cli/PropertyFileDefaultProvider.java
@@ -3,10 +3,7 @@ package org.schemaspy.cli;
 import com.beust.jcommander.IDefaultProvider;
 import org.springframework.util.FileCopyUtils;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.StringReader;
+import java.io.*;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -31,10 +28,9 @@ public class PropertyFileDefaultProvider implements IDefaultProvider {
     }
 
     private static Properties loadProperties(String path) {
-        try {
-            FileInputStream inputStream = new FileInputStream(path);
+        try (Reader reader = new InputStreamReader(new FileInputStream(path), "UTF-8")){
             Properties properties = new Properties();
-            String contents = FileCopyUtils.copyToString(new InputStreamReader(inputStream, "UTF-8"));
+            String contents = FileCopyUtils.copyToString(reader);
             // Replace backslashes with double backslashes to escape windows path separator.
             // Example input: schemaspy.o=C:\tools\schemaspy\output
             properties.load(new StringReader(contents.replace("\\", "\\\\")));

--- a/src/main/java/org/schemaspy/util/DiagramUtil.java
+++ b/src/main/java/org/schemaspy/util/DiagramUtil.java
@@ -6,6 +6,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.file.Files;
 import java.util.List;
 
 /**
@@ -13,13 +14,14 @@ import java.util.List;
  */
 public class DiagramUtil {
 
-    public static void generateDiagram(String diagramName, Dot dot, File dotFile, File diagramFile, List<MustacheTableDiagram> diagrams, boolean isActive, boolean isImplied) throws Dot.DotFailure {
+    public static void generateDiagram(String diagramName, Dot dot, File dotFile, File diagramFile, List<MustacheTableDiagram> diagrams, boolean isActive, boolean isImplied) throws IOException {
         if (dotFile.exists()) {
             String mapDegreesDotFile = dot.generateDiagram(dotFile, diagramFile);
             createDiagram(diagramName, diagramFile, mapDegreesDotFile, diagrams, isActive, isImplied);
         } else {
-            dotFile.delete();
-            diagramFile.delete();
+            Files.deleteIfExists(dotFile.toPath());
+            Files.deleteIfExists(diagramFile.toPath());
+
         }
     }
 

--- a/src/main/java/org/schemaspy/util/Dot.java
+++ b/src/main/java/org/schemaspy/util/Dot.java
@@ -18,9 +18,12 @@
  */
 package org.schemaspy.util;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.schemaspy.Config;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -302,18 +305,13 @@ public class Dot {
         } catch (InterruptedException interrupted) {
             throw new RuntimeException(interrupted);
         } catch (DotFailure failed) {
-            diagramFile.delete();
+            FileUtils.deleteQuietly(diagramFile);
             throw failed;
         } catch (IOException failed) {
-            diagramFile.delete();
+            FileUtils.deleteQuietly(diagramFile);
             throw new DotFailure("'" + commandLine + "' failed with exception " + failed);
         } finally {
-            if (mapReader != null) {
-                try {
-                    mapReader.close();
-                } catch (IOException ignore) {
-                }
-            }
+            IOUtils.closeQuietly(mapReader);
         }
     }
 

--- a/src/main/java/org/schemaspy/util/ResourceWriter.java
+++ b/src/main/java/org/schemaspy/util/ResourceWriter.java
@@ -94,7 +94,7 @@ public class ResourceWriter {
 
 
                     if (jarEntry.isDirectory()) {
-                        currentFile.mkdirs();
+                        FileUtils.forceMkdir(currentFile);
                     } else {
                         if (filter == null || filter.accept(currentFile)) {
                             InputStream is = jarFile.getInputStream(jarEntry);

--- a/src/main/java/org/schemaspy/view/HtmlOrphansPage.java
+++ b/src/main/java/org/schemaspy/view/HtmlOrphansPage.java
@@ -93,13 +93,10 @@ public class HtmlOrphansPage extends HtmlDiagramFormatter {
                 File dotFile = new File(diagramDir, dotBaseFilespec + ".1degree.dot");
                 File imgFile = new File(diagramDir, dotBaseFilespec + ".1degree." + dot.getFormat());
 
-                LineWriter dotOut = new LineWriter(dotFile, Config.DOT_CHARSET);
-                try {
+                try (LineWriter dotOut = new LineWriter(dotFile, Config.DOT_CHARSET)) {
                     DotFormatter.getInstance().writeOrphan(table, dotOut, outputDir);
                 } catch (IOException e) {
-                    throw  new IOException(e);
-                } finally {
-                    dotOut.close();
+                    throw new IOException(e);
                 }
 
                 try {

--- a/src/main/java/org/schemaspy/view/HtmlTablePage.java
+++ b/src/main/java/org/schemaspy/view/HtmlTablePage.java
@@ -27,6 +27,7 @@ import org.schemaspy.util.Markdown;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.*;
 
 /**
@@ -160,14 +161,14 @@ public class HtmlTablePage extends HtmlFormatter {
 
         // delete before we start because we'll use the existence of these files to determine
         // if they should be turned into pngs & presented
-        oneDegreeDotFile.delete();
-        oneDegreeDiagramFile.delete();
-        twoDegreesDotFile.delete();
-        twoDegreesDiagramFile.delete();
-        oneImpliedDotFile.delete();
-        oneImpliedDiagramFile.delete();
-        twoImpliedDotFile.delete();
-        twoImpliedDiagramFile.delete();
+        Files.deleteIfExists(oneDegreeDotFile.toPath());
+        Files.deleteIfExists(oneDegreeDiagramFile.toPath());
+        Files.deleteIfExists(twoDegreesDotFile.toPath());
+        Files.deleteIfExists(twoDegreesDiagramFile.toPath());
+        Files.deleteIfExists(oneImpliedDotFile.toPath());
+        Files.deleteIfExists(oneImpliedDiagramFile.toPath());
+        Files.deleteIfExists(twoImpliedDotFile.toPath());
+        Files.deleteIfExists(twoImpliedDiagramFile.toPath());
 
 
         if (table.getMaxChildren() + table.getMaxParents() > 0) {
@@ -185,7 +186,7 @@ public class HtmlTablePage extends HtmlFormatter {
             dotOut.close();
 
             if (oneStats.getNumTablesWritten() + oneStats.getNumViewsWritten() == twoStats.getNumTablesWritten() + twoStats.getNumViewsWritten()) {
-                twoDegreesDotFile.delete(); // no different than before, so don't show it
+                Files.deleteIfExists(twoDegreesDotFile.toPath()); // no different than before, so don't show it
             }
 
             if (!impliedConstraints.isEmpty()) {


### PR DESCRIPTION
There are several Sonar warnings around "Do something with the "boolean" value returned by "delete"".

HtmlTablePage.java in particular attempts to delete all of the files that will be generated, but doesn't check to see if they were actually deleted. Its possible that the files could be locked by another process.

A couple different changes were made, trying to keep with the intent of the original code while providing better error handling.

* [FileUtils.forceMkdir](https://github.com/apache/commons-io/blob/master/src/main/java/org/apache/commons/io/FileUtils.java#L2474) - Will throw an exception if the input already exists but is not a directory, otherwise attempts to call mkdirs. If that fails, throws an IOException
* Files.deleteIfExists - deletes a file if it exists, throws an IOException if it exists and can't be deleted (ie: the file is locked by another process)
* FileUtils.deleteQuietly - added in a couple of exception handlers