### PR TITLE
Moving xml generation separate package

### DIFF
--- a/src/main/java/org/schemaspy/output/OutputException.java
+++ b/src/main/java/org/schemaspy/output/OutputException.java
@@ -1,0 +1,7 @@
+package org.schemaspy.output;
+
+public class OutputException extends RuntimeException {
+    public OutputException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/schemaspy/output/OutputProducer.java
+++ b/src/main/java/org/schemaspy/output/OutputProducer.java
@@ -1,0 +1,9 @@
+package org.schemaspy.output;
+
+import org.schemaspy.model.Database;
+
+import java.io.File;
+
+public interface OutputProducer {
+    void generate(Database database, File outputDir);
+}

--- a/src/main/java/org/schemaspy/output/xml/XmlProducer.java
+++ b/src/main/java/org/schemaspy/output/xml/XmlProducer.java
@@ -1,0 +1,6 @@
+package org.schemaspy.output.xml;
+
+import org.schemaspy.output.OutputProducer;
+
+public interface XmlProducer extends OutputProducer {
+}

--- a/src/main/java/org/schemaspy/output/xml/XmlProducerException.java
+++ b/src/main/java/org/schemaspy/output/xml/XmlProducerException.java
@@ -1,0 +1,9 @@
+package org.schemaspy.output.xml;
+
+import org.schemaspy.output.OutputException;
+
+public class XmlProducerException extends OutputException {
+    public XmlProducerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/schemaspy/output/xml/dom/DOMUtil.java
+++ b/src/main/java/org/schemaspy/output/xml/dom/DOMUtil.java
@@ -16,39 +16,11 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.schemaspy.util;
+package org.schemaspy.output.xml.dom;
 
-import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Node;
 
 public class DOMUtil {
-    public static void printDOM(Node node, LineWriter out) throws TransformerException {
-        TransformerFactory factory = TransformerFactory.newInstance();
-        Transformer xformer;
-        boolean indentSpecified = false;
-
-        // see http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=6296446
-        // for issues about transformations in Java 5.x
-        try {
-            // won't work pre-5.x
-            factory.setAttribute("indent-number", 3);
-            indentSpecified = true;
-        } catch (IllegalArgumentException factoryDoesntSupportIndentNumber) {
-        }
-
-        xformer = factory.newTransformer();
-        xformer.setOutputProperty(OutputKeys.INDENT, "yes");
-        if (!indentSpecified)
-            xformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "3");
-
-        xformer.transform(new DOMSource(node), new StreamResult(out));
-    }
-
     /**
      * Append the specified key/value pair of attributes to the <code>Node</code>.
      * @param node Node

--- a/src/main/java/org/schemaspy/output/xml/dom/XmlProducerUsingDOM.java
+++ b/src/main/java/org/schemaspy/output/xml/dom/XmlProducerUsingDOM.java
@@ -1,0 +1,96 @@
+package org.schemaspy.output.xml.dom;
+
+import org.schemaspy.model.Database;
+import org.schemaspy.model.Table;
+import org.schemaspy.output.xml.XmlProducer;
+import org.schemaspy.output.xml.XmlProducerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.*;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+
+public class XmlProducerUsingDOM implements XmlProducer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    @Override
+    public void generate(Database database, File outputDir) {
+        Collection<Table> tables = new ArrayList<Table>(database.getTables());
+        tables.addAll(database.getViews());
+
+        if (tables.isEmpty()) {
+            LOGGER.info("No tables to output, nothing written to disk");
+            return;
+        }
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder;
+        try {
+            builder = factory.newDocumentBuilder();
+        } catch (ParserConfigurationException exc) {
+            throw new XmlProducerException("Failed to get a newDocumentBuilder()",exc);
+        }
+
+        Document document = builder.newDocument();
+        Element rootNode = document.createElement("database");
+        document.appendChild(rootNode);
+        DOMUtil.appendAttribute(rootNode, "name", database.getName());
+        if (Objects.nonNull(database.getSchema()))
+            DOMUtil.appendAttribute(rootNode, "schema", database.getSchema().getName());
+        DOMUtil.appendAttribute(rootNode, "type", database.getDatabaseProduct());
+
+        XmlTableFormatter.getInstance().appendTables(rootNode, tables);
+
+        String xmlName = database.getName();
+
+        // some dbNames have path info in the name...strip it
+        xmlName = new File(xmlName).getName();
+
+        // some dbNames include jdbc driver details including :'s and @'s
+        String[] unusables = xmlName.split("[:@]");
+        xmlName = unusables[unusables.length - 1];
+
+        if (Objects.nonNull(database.getSchema()))
+            xmlName += '.' + database.getSchema().getName();
+
+        document.getDocumentElement().normalize();
+        Path xmlFile = outputDir.toPath().resolve(xmlName + ".xml");
+        try (Writer writer = Files.newBufferedWriter(xmlFile, StandardCharsets.UTF_8)){
+            write(document, writer);
+        } catch (IOException e) {
+            throw new XmlProducerException("Unable to write xml to disk", e);
+        } catch (TransformerException e) {
+            throw new XmlProducerException("Unable to transform dom document to xml", e);
+        }
+    }
+
+    private void write(Document document, Writer writer) throws TransformerException {
+        TransformerFactory tf = TransformerFactory.newInstance();
+        Transformer transformer = tf.newTransformer();
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+        transformer.setOutputProperty(OutputKeys.METHOD, "xml");
+        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+        transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "3");
+
+        transformer.transform(new DOMSource(document),
+                new StreamResult(writer));
+    }
+}

--- a/src/main/java/org/schemaspy/output/xml/dom/XmlTableFormatter.java
+++ b/src/main/java/org/schemaspy/output/xml/dom/XmlTableFormatter.java
@@ -16,7 +16,7 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-package org.schemaspy.view;
+package org.schemaspy.output.xml.dom;
 
 import java.util.Collection;
 import java.util.Comparator;
@@ -28,7 +28,6 @@ import org.schemaspy.model.ForeignKeyConstraint;
 import org.schemaspy.model.Table;
 import org.schemaspy.model.TableColumn;
 import org.schemaspy.model.TableIndex;
-import org.schemaspy.util.DOMUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;


### PR DESCRIPTION
Moving xml generation out of SchemaAnalyzer.
Making it possible to add more OutputProducers.

It can now easily be replaced with an alternative to DOM or even add json if that is something one would like.