### PR TITLE
More relaxed handling on missing Database/ResultSetMetadata

### DIFF
--- a/src/main/java/org/schemaspy/service/InconsistencyException.java
+++ b/src/main/java/org/schemaspy/service/InconsistencyException.java
@@ -1,0 +1,7 @@
+package org.schemaspy.service;
+
+public class InconsistencyException extends RuntimeException {
+    public InconsistencyException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/org/schemaspy/types/hive.properties
+++ b/src/main/resources/org/schemaspy/types/hive.properties
@@ -1,0 +1,13 @@
+# see http://schemaspy.org/dbtypes.html
+# for configuration / customization details
+
+description=Hive
+connectionSpec=jdbc:hive2://<host>:<port>/<db>
+host=database host
+port=database port
+db=database name
+driver=org.apache.hive.jdbc.HiveDriver
+
+# Sample path to the H2 drivers available at http://www.h2database.com
+# Use -dp to override.
+driverPath=/lib/hive-jdbc-2.1.0.2.6.3.0-235-standalone.jar


### PR DESCRIPTION
* We have an SQL92 keywords list, so we don't need to fail if we can't
  get from database
* If we can't retrieve column from table model using ResulSetMetaData
  check if it contains table/fulltable name in the MetaData and strip it.
  If it's still not found throw an InconsistencyException (this is for
  when DatabaseMetaData returns columns in one way and ResultSetMetaData
  in another.
* Added basic hive dbtype connectionSpec/connectionString has a bunch of
  options: https://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.3.0/bk_dataintegration/content/hive-jdbc-odbc-drivers.html