### PR TITLE
added @REM to mvnw to '#', made DotTest only run on linux

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -121,7 +121,7 @@ SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
 set WRAPPER_JAR=""%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar""
 set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
 
-# avoid using MAVEN_CMD_LINE_ARGS below since that would loose parameter escaping in %*
+@REM # avoid using MAVEN_CMD_LINE_ARGS below since that would loose parameter escaping in %*
 %MAVEN_JAVA_EXE% %JVM_CONFIG_MAVEN_PROPS% %MAVEN_OPTS% %MAVEN_DEBUG_OPTS% -classpath %WRAPPER_JAR% "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
 if ERRORLEVEL 1 goto error
 goto end

--- a/src/test/java/org/schemaspy/util/DotTest.java
+++ b/src/test/java/org/schemaspy/util/DotTest.java
@@ -8,11 +8,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assume.assumeThat;
 
 public class DotTest {
 
     @Test
     public void version2_26_0() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        assumeThat(System.getProperty("os.name"), is("Linux"));
         Config config = Config.getInstance();
         config.setGraphvizDir(Paths.get("src/test/resources/dotFakes/2.26.0").toAbsolutePath().toFile());
         Dot dot = createDot();
@@ -21,6 +24,7 @@ public class DotTest {
 
     @Test
     public void version2_28_0() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        assumeThat(System.getProperty("os.name"), is("Linux"));
         Config config = Config.getInstance();
         config.setGraphvizDir(Paths.get("src/test/resources/dotFakes/2.28.0").toAbsolutePath().toFile());
         Dot dot = createDot();
@@ -29,6 +33,7 @@ public class DotTest {
 
     @Test
     public void version2_32_0() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        assumeThat(System.getProperty("os.name"), is("Linux"));
         Config config = Config.getInstance();
         config.setGraphvizDir(Paths.get("src/test/resources/dotFakes/2.32.0").toAbsolutePath().toFile());
         Dot dot = createDot();
@@ -36,6 +41,7 @@ public class DotTest {
     }
 
     private Dot createDot() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        assumeThat(System.getProperty("os.name"), is("Linux"));
         Constructor<Dot> ctor = Dot.class.getDeclaredConstructor(new Class[0]);
         ctor.setAccessible(true);
         Dot dot = ctor.newInstance();


### PR DESCRIPTION
* mvnw.cmd had a comment using # which is invalid for windows @REM is used
* DotTest works only on linux, everything executes from shell or have the #!
  instruction, it doesn't work the same way on windows, and it would require
  a modification in Dot.java to be able to use a shim as we do in the test.