### PR TITLE
More cleanups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,12 @@
             <version>2.3.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <version>2.4</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/src/main/java/org/schemaspy/Config.java
+++ b/src/main/java/org/schemaspy/Config.java
@@ -488,7 +488,7 @@ public final class Config {
      * @throws FileNotFoundException
      * @throws IOException
      */
-    public void setConnectionPropertiesFile(String propertiesFilename) throws FileNotFoundException, IOException {
+    public void setConnectionPropertiesFile(String propertiesFilename) throws IOException {
         if (userConnectionProperties == null)
             userConnectionProperties = new Properties();
         userConnectionProperties.load(new FileInputStream(propertiesFilename));
@@ -504,11 +504,11 @@ public final class Config {
      * @throws FileNotFoundException
      * @throws IOException
      */
-    public Properties getConnectionProperties() throws FileNotFoundException, IOException {
+    public Properties getConnectionProperties() throws IOException {
         if (userConnectionProperties == null) {
             String props = pullParam("-connprops");
             if (props != null) {
-                if (props.indexOf(ESCAPED_EQUALS) != -1) {
+                if (props.contains(ESCAPED_EQUALS)) {
                     setConnectionProperties(props);
                 } else {
                     setConnectionPropertiesFile(props);
@@ -634,10 +634,10 @@ public final class Config {
                     LOGGER.warn(e.getMessage(), e);
                 }
             }
-            fontSize = Integer.valueOf(size);
+            fontSize = size;
         }
 
-        return fontSize.intValue();
+        return fontSize;
     }
 
     /**
@@ -1521,8 +1521,8 @@ public final class Config {
 
             BeanInfo beanInfo = Introspector.getBeanInfo(Config.class);
             PropertyDescriptor[] props = beanInfo.getPropertyDescriptors();
-            for (int i = 0; i < props.length; ++i) {
-                Method readMethod = props[i].getReadMethod();
+            for (PropertyDescriptor prop : props) {
+                Method readMethod = prop.getReadMethod();
                 if (readMethod != null)
                     readMethod.invoke(this, (Object[]) null);
             }
@@ -1541,7 +1541,7 @@ public final class Config {
 
             while ((entry = jar.getNextJarEntry()) != null) {
                 String entryName = entry.getName();
-                if (entryName.indexOf("types") != -1) {
+                if (entryName.contains("types")) {
                     int dotPropsIndex = entryName.indexOf(".properties");
                     if (dotPropsIndex != -1)
                         databaseTypes.add(entryName.substring(0, dotPropsIndex));

--- a/src/main/java/org/schemaspy/Config.java
+++ b/src/main/java/org/schemaspy/Config.java
@@ -1624,15 +1624,14 @@ public final class Config {
         try {
             BeanInfo beanInfo = Introspector.getBeanInfo(Config.class);
             PropertyDescriptor[] props = beanInfo.getPropertyDescriptors();
-            for (int i = 0; i < props.length; ++i) {
-                PropertyDescriptor prop = props[i];
+            for (PropertyDescriptor prop : props) {
                 if (prop.getName().equalsIgnoreCase(paramName)) {
                     Object result = prop.getReadMethod().invoke(this, (Object[]) null);
                     return result == null ? null : result.toString();
                 }
             }
         } catch (Exception failed) {
-            failed.printStackTrace();
+            LOGGER.error("Unable to get parameter {}",paramName,failed);
         }
 
         return null;
@@ -1649,8 +1648,9 @@ public final class Config {
         List<String> params = new ArrayList<>();
 
         if (originalDbSpecificOptions != null) {
-            for (String key : originalDbSpecificOptions.keySet()) {
-                String value = originalDbSpecificOptions.get(key);
+            for (Entry<String,String> entry : originalDbSpecificOptions.entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
                 if (!key.startsWith("-"))
                     key = "-" + key;
                 params.add(key);

--- a/src/main/java/org/schemaspy/DbAnalyzer.java
+++ b/src/main/java/org/schemaspy/DbAnalyzer.java
@@ -41,7 +41,7 @@ public class DbAnalyzer {
         // gather all the primary key columns and columns without parents
         for (Table table : tables) {
             List<TableColumn> tablePrimaries = table.getPrimaryColumns();
-            if (tablePrimaries.size() == 1 || tablePrimaries.stream().filter(t-> t.getName().equals("LanguageId")).count() > 0) { // can't match up multiples...yet...
+            if (tablePrimaries.size() == 1 || tablePrimaries.stream().anyMatch(t -> t.getName().equals("LanguageId"))) { // can't match up multiples...yet...
             	TableColumn tableColumn = tablePrimaries.get(0);
                 DatabaseObject primary = new DatabaseObject(tableColumn);
                 if (tableColumn.allowsImpliedChildren()) {
@@ -257,25 +257,17 @@ public class DbAnalyzer {
     }
 
     public static List<Table> sortTablesByName(List<Table> tables) {
-        Collections.sort(tables, new Comparator<Table>() {
-            @Override
-			public int compare(Table table1, Table table2) {
-                return table1.compareTo(table2);
-            }
-        });
+        tables.sort(Table::compareTo);
 
         return tables;
     }
 
     public static List<TableColumn> sortColumnsByTable(List<TableColumn> columns) {
-        Collections.sort(columns, new Comparator<TableColumn>() {
-            @Override
-			public int compare(TableColumn column1, TableColumn column2) {
-                int rc = column1.getTable().compareTo(column2.getTable());
-                if (rc == 0)
-                    rc = column1.getName().compareToIgnoreCase(column2.getName());
-                return rc;
-            }
+        columns.sort((column1, column2) -> {
+            int rc = column1.getTable().compareTo(column2.getTable());
+            if (rc == 0)
+                rc = column1.getName().compareToIgnoreCase(column2.getName());
+            return rc;
         });
 
         return columns;

--- a/src/main/java/org/schemaspy/DbAnalyzer.java
+++ b/src/main/java/org/schemaspy/DbAnalyzer.java
@@ -58,7 +58,6 @@ public class DbAnalyzer {
         }
 
         sortColumnsByTable(columnsWithoutParents);
-        Set<DatabaseObject> primaryColumns = keyedTablesByPrimary.keySet();
         List<ImpliedForeignKeyConstraint> impliedConstraints = new ArrayList<ImpliedForeignKeyConstraint>();
         
         for (TableColumn childColumn : columnsWithoutParents) {

--- a/src/main/java/org/schemaspy/DbDriverLoader.java
+++ b/src/main/java/org/schemaspy/DbDriverLoader.java
@@ -151,9 +151,7 @@ public class DbDriverLoader {
         File driverFolder = new File(Paths.get(driverPath).getParent().toString());
         if (driverFolder != null) {
             File[] files = driverFolder.listFiles(
-                    (dir, name) -> {
-                        return name.toLowerCase().matches(".*\\.?ar$");
-                    }
+                    (dir, name) -> name.toLowerCase().matches(".*\\.?ar$")
             );
 
             LOGGER.info("Additional files will be loaded for JDBC Driver");

--- a/src/main/java/org/schemaspy/DbDriverLoader.java
+++ b/src/main/java/org/schemaspy/DbDriverLoader.java
@@ -57,7 +57,7 @@ public class DbDriverLoader {
             connectionProperties.put("password", config.getPassword());
         }
 
-        Connection connection = null;
+        Connection connection;
         try {
             connection = driver.connect(connectionURL, connectionProperties);
             if (connection == null) {
@@ -113,7 +113,7 @@ public class DbDriverLoader {
 
 
         ClassLoader loader = getDriverClassLoader(classpath);
-        Driver driver = null;
+        Driver driver;
 
         try {
             driver = (Driver)Class.forName(driverClass, true, loader).newInstance();

--- a/src/main/java/org/schemaspy/SchemaAnalyzer.java
+++ b/src/main/java/org/schemaspy/SchemaAnalyzer.java
@@ -206,8 +206,6 @@ public class SchemaAnalyzer {
 
             long duration = progressListener.startedGraphingSummaries();
 
-            schemaMeta = null; // done with it so let GC reclaim it
-
             Collection<Table> tables = new ArrayList<Table>(db.getTables());
             tables.addAll(db.getViews());
 
@@ -233,8 +231,6 @@ public class SchemaAnalyzer {
                            }
                         }
                     });
-
-            meta = null;
 
             List<ForeignKeyConstraint> recursiveConstraints = new ArrayList<ForeignKeyConstraint>();
 
@@ -404,7 +400,6 @@ public class SchemaAnalyzer {
      */
     private void prepareLayoutFiles(File outputDir) throws IOException {
         URL url = getClass().getResource("/layout");
-        File directory = new File(url.getPath());
 
         IOFileFilter notHtmlFilter = FileFilterUtils.notFileFilter(FileFilterUtils.suffixFileFilter(".html"));
         FileFilter filter = FileFilterUtils.and(notHtmlFilter);

--- a/src/main/java/org/schemaspy/TableOrderer.java
+++ b/src/main/java/org/schemaspy/TableOrderer.java
@@ -121,11 +121,7 @@ public class TableOrderer {
         List<Table> ordered = new ArrayList<Table>(heads.size() + tails.size());
 
         ordered.addAll(heads);
-        heads = null; // allow gc ASAP
-
         ordered.addAll(tails);
-        tails = null; // allow gc ASAP
-
         ordered.addAll(unattached);
 
         return ordered;

--- a/src/main/java/org/schemaspy/db/config/PropertiesFinder.java
+++ b/src/main/java/org/schemaspy/db/config/PropertiesFinder.java
@@ -46,7 +46,7 @@ public class PropertiesFinder implements ResourceFinder {
             try {
                 return path.toUri().toURL();
             } catch (MalformedURLException e) {
-                LOGGER.debug("Couldn't convert existing file: "+path.toString(), e);
+                LOGGER.debug("Couldn't convert existing file: {}", path.toString(), e);
                 return null;
             }
         }

--- a/src/main/java/org/schemaspy/db/config/PropertiesResolver.java
+++ b/src/main/java/org/schemaspy/db/config/PropertiesResolver.java
@@ -60,9 +60,7 @@ public class PropertiesResolver {
         Map<String,String> includes = props.entrySet().stream()
                 .filter(isInclude)
                 .collect(Collectors.toMap(e -> e.getKey().toString(), e -> e.getValue().toString()));
-        includes.keySet().forEach(k -> {
-                    props.remove(k);
-        });
+        includes.keySet().forEach(props::remove);
         includes.values().stream()
                 .map( s -> s.split("::"))
                 .forEach( ref -> {
@@ -92,7 +90,7 @@ public class PropertiesResolver {
         Properties parentProperties;
         if (Objects.nonNull(parentDbType)) {
             parentProperties = resolve(parentDbType.trim(), resolutionInfo);
-            parentProperties.forEach((k,v) -> props.putIfAbsent(k,v));
+            parentProperties.forEach(props::putIfAbsent);
         }
     }
 

--- a/src/main/java/org/schemaspy/model/Catalog.java
+++ b/src/main/java/org/schemaspy/model/Catalog.java
@@ -24,28 +24,23 @@ import java.util.Objects;
 import org.schemaspy.util.CaseInsensitiveMap;
 
 public final class Catalog implements Comparable<Catalog>{
-    private String name;
-    private String comment = null;
+    private final String name;
+    private String comment;
 
 	public Catalog(String name) {
-		super();
-		Objects.requireNonNull(name);
-		this.name = name;
+		this(name,null);
+
 	}
 	
 	public Catalog(String name, String comment) {
-		this(name);
-		this.name = name;
+		this.name = Objects.requireNonNull(name);
 		this.comment = comment;
 	}
 	
 	public String getName() {
 		return name;
 	}
-	public void setName(String name) {
-		this.name = name;
-	}
-	
+
 	public String getComment() {
 		return comment;
 	}
@@ -67,7 +62,6 @@ public final class Catalog implements Comparable<Catalog>{
 	}
 
 	@Override public int hashCode() {
-
-		return Objects.hash(name);
+		return name.hashCode();
 	}
 }

--- a/src/main/java/org/schemaspy/model/Catalog.java
+++ b/src/main/java/org/schemaspy/model/Catalog.java
@@ -18,10 +18,7 @@
  */
 package org.schemaspy.model;
 
-import java.util.Map;
 import java.util.Objects;
-
-import org.schemaspy.util.CaseInsensitiveMap;
 
 public final class Catalog implements Comparable<Catalog>{
     private final String name;

--- a/src/main/java/org/schemaspy/model/Catalog.java
+++ b/src/main/java/org/schemaspy/model/Catalog.java
@@ -19,25 +19,22 @@
 package org.schemaspy.model;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.schemaspy.util.CaseInsensitiveMap;
 
 public final class Catalog implements Comparable<Catalog>{
     private String name;
     private String comment = null;
-    private Map<String, Schema> schemas = new CaseInsensitiveMap<Schema>();
-    
+
 	public Catalog(String name) {
 		super();
-		 if (name == null)
-	            throw new IllegalArgumentException("Catalog name can't be null");
+		Objects.requireNonNull(name);
 		this.name = name;
 	}
 	
 	public Catalog(String name, String comment) {
-		super();
-		 if (name == null)
-	            throw new IllegalArgumentException("Catalog name can't be null");
+		this(name);
 		this.name = name;
 		this.comment = comment;
 	}
@@ -61,5 +58,16 @@ public final class Catalog implements Comparable<Catalog>{
     public String toString() {
         return name;
     }
-    
+
+	@Override public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Catalog catalog = (Catalog) o;
+		return Objects.equals(name, catalog.name);
+	}
+
+	@Override public int hashCode() {
+
+		return Objects.hash(name);
+	}
 }

--- a/src/main/java/org/schemaspy/model/Database.java
+++ b/src/main/java/org/schemaspy/model/Database.java
@@ -284,14 +284,14 @@ public class Database {
      */
     private Pattern getInvalidIdentifierPattern() throws SQLException {
         if (invalidIdentifierPattern == null) {
-            String validChars = "a-zA-Z0-9_";
+            StringBuilder validChars = new StringBuilder("a-zA-Z0-9_");
             String reservedRegexChars = "-&^";
             String extraValidChars = getMetaData().getExtraNameCharacters();
             for (int i = 0; i < extraValidChars.length(); ++i) {
                 char ch = extraValidChars.charAt(i);
                 if (reservedRegexChars.indexOf(ch) >= 0)
-                    validChars += "" + "\\";
-                validChars += ch;
+                    validChars.append("" + "\\");
+                validChars.append(ch);
             }
 
             invalidIdentifierPattern = Pattern.compile("[^" + validChars + "]");

--- a/src/main/java/org/schemaspy/model/ForeignKeyConstraint.java
+++ b/src/main/java/org/schemaspy/model/ForeignKeyConstraint.java
@@ -369,11 +369,7 @@ public class ForeignKeyConstraint implements Comparable<ForeignKeyConstraint> {
             return false;
         }
 
-        if (this.parentTable != ((ForeignKeyConstraint)obj).parentTable) {
-            return false;
-        }
-
-        return true;
+        return this.parentTable == ((ForeignKeyConstraint) obj).parentTable;
     }
 
     @Override

--- a/src/main/java/org/schemaspy/model/Schema.java
+++ b/src/main/java/org/schemaspy/model/Schema.java
@@ -19,29 +19,22 @@
 package org.schemaspy.model;
 
 
+import java.util.Objects;
+
 public final class Schema implements Comparable<Schema>{
-	public String name;
+	public final String name;
 	public String comment =null;
     
 	public Schema(String name, String comment) {
-		super();
-		 if (name == null)
-	            throw new IllegalArgumentException("Schema name can't be null");
-		this.name = name;
+		this.name = Objects.requireNonNull(name);
 		this.comment = comment;
 	}
 	public Schema(String name) {
-		super();
-		 if (name == null)
-	            throw new IllegalArgumentException("Schema name can't be null");
-		this.name = name;
+		this(name,null);
 	}
 	
 	public String getName() {
 		return name;
-	}
-	public void setName(String name) {
-		this.name = name;
 	}
 	
 	public String getComment() {
@@ -56,4 +49,15 @@ public final class Schema implements Comparable<Schema>{
     public String toString() {
         return name;
     }
+
+	@Override public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Schema schema = (Schema) o;
+		return Objects.equals(name, schema.name);
+	}
+
+	@Override public int hashCode() {
+		return name.hashCode();
+	}
 }

--- a/src/main/java/org/schemaspy/model/TableIndex.java
+++ b/src/main/java/org/schemaspy/model/TableIndex.java
@@ -20,10 +20,7 @@ package org.schemaspy.model;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 public class TableIndex implements Comparable<TableIndex> {
     private final String name;
@@ -38,8 +35,12 @@ public class TableIndex implements Comparable<TableIndex> {
      * @throws java.sql.SQLException
      */
     public TableIndex(ResultSet rs) throws SQLException {
-        name = rs.getString("INDEX_NAME");
-        isUnique = !rs.getBoolean("NON_UNIQUE");
+        this(rs.getString("INDEX_NAME"),!rs.getBoolean("NON_UNIQUE"));
+
+    }
+    public TableIndex(String name, boolean unique) {
+        this.name = name;
+        this.isUnique = unique;
     }
 
     public void setId(Object id) {
@@ -153,5 +154,27 @@ public class TableIndex implements Comparable<TableIndex> {
         if (thisId instanceof Number)
             return ((Number)thisId).intValue() - ((Number)otherId).intValue();
         return thisId.toString().compareToIgnoreCase(otherId.toString());
+    }
+
+    @Override public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+        Object thisId = getId();
+        Object otherId = ((TableIndex)other).getId();
+        if (thisId == null || otherId == null)
+            return getName().equalsIgnoreCase(((TableIndex)other).getName());
+        if (thisId instanceof Number)
+            return thisId.equals(otherId);
+        return thisId.toString().equalsIgnoreCase(otherId.toString());
+    }
+    @Override public int hashCode() {
+        Object thisId = getId();
+        if (thisId == null) {
+        	return Objects.hash(name);
+		}
+        if (thisId instanceof Number) {
+            return (Objects.hash(thisId));
+        }
+        return Objects.hash(thisId.toString().toLowerCase());
     }
 }

--- a/src/main/java/org/schemaspy/model/TableIndex.java
+++ b/src/main/java/org/schemaspy/model/TableIndex.java
@@ -133,7 +133,7 @@ public class TableIndex implements Comparable<TableIndex> {
      * @return
      */
     public boolean isAscending(TableColumn column) {
-        return columnsAscending.get(columns.indexOf(column)).booleanValue();
+        return columnsAscending.get(columns.indexOf(column));
     }
 
     /**

--- a/src/main/java/org/schemaspy/output/xml/dom/XmlTableFormatter.java
+++ b/src/main/java/org/schemaspy/output/xml/dom/XmlTableFormatter.java
@@ -287,9 +287,9 @@ public class XmlTableFormatter {
     private String asBinary(String str) {
         byte[] bytes = str.getBytes();
         StringBuilder buf = new StringBuilder(bytes.length * 2);
-        for (int i = 0; i < bytes.length; ++i) {
-            buf.append(String.format("%02X", bytes[i]));
-        }
+		for (byte aByte : bytes) {
+			buf.append(String.format("%02X", aByte));
+		}
         return buf.toString();
     }
 }

--- a/src/main/java/org/schemaspy/service/DatabaseService.java
+++ b/src/main/java/org/schemaspy/service/DatabaseService.java
@@ -321,14 +321,14 @@ public class DatabaseService {
         }
 
         @Override
-        void create(Database db, BasicTableMeta tableMeta, ProgressListener listener) throws SQLException {
+        void create(Database db, BasicTableMeta tableMeta, ProgressListener listener) {
             Thread runner = new Thread() {
                 @Override
                 public void run() {
                     try {
                         createImpl(db, tableMeta, listener);
                     } catch (SQLException exc) {
-                        exc.printStackTrace(); // nobody above us in call stack...dump it here
+                        LOGGER.error("SQL exception",exc);
                     } finally {
                         synchronized (threads) {
                             threads.remove(this);

--- a/src/main/java/org/schemaspy/util/DiagramUtil.java
+++ b/src/main/java/org/schemaspy/util/DiagramUtil.java
@@ -1,11 +1,14 @@
 package org.schemaspy.util;
 
 import org.schemaspy.view.MustacheTableDiagram;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
+import java.lang.invoke.MethodHandles;
 import java.nio.file.Files;
 import java.util.List;
 
@@ -13,6 +16,7 @@ import java.util.List;
  * Created by rkasa on 2016-04-16.
  */
 public class DiagramUtil {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public static void generateDiagram(String diagramName, Dot dot, File dotFile, File diagramFile, List<MustacheTableDiagram> diagrams, boolean isActive, boolean isImplied) throws IOException {
         if (dotFile.exists()) {
@@ -36,7 +40,6 @@ public class DiagramUtil {
         diagram.setMapName(diagramMapName(diagramMap));
         diagram.setIsImplied(isImplied);
         diagrams.add(diagram);
-        diagramMap = null;
     }
 
     private static String diagramMapName(String diagramMap) {
@@ -49,7 +52,7 @@ public class DiagramUtil {
                 diagramMapName = line.substring(9,line.indexOf("name")-2);
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.error("Error reading diagram map",e);
         }
         return diagramMapName;
     }

--- a/src/main/java/org/schemaspy/util/Dot.java
+++ b/src/main/java/org/schemaspy/util/Dot.java
@@ -46,7 +46,7 @@ public class Dot {
     private final Set<String> validatedRenderers = Collections.synchronizedSet(new HashSet<String>());
     private final Set<String> invalidatedRenderers = Collections.synchronizedSet(new HashSet<String>());
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private static final String CAIRO_RENDERER = ":cairo";
     private static final String GD_RENDERER = ":gd";
@@ -336,6 +336,7 @@ public class Dot {
     }
 
     private static class ProcessOutputReader extends Thread {
+		private final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
         private final BufferedReader processReader;
         private final String command;
 

--- a/src/main/java/org/schemaspy/util/Dot.java
+++ b/src/main/java/org/schemaspy/util/Dot.java
@@ -199,7 +199,7 @@ public class Dot {
      * @see #setHighQuality(boolean)
      */
     public boolean isHighQuality() {
-        return getRenderer().indexOf(CAIRO_RENDERER) != -1;
+        return getRenderer().contains(CAIRO_RENDERER);
     }
 
     /**
@@ -352,7 +352,7 @@ public class Dot {
                 String line;
                 while ((line = processReader.readLine()) != null) {
                     // don't report port id unrecognized or unrecognized port
-                    if (line.indexOf("unrecognized") == -1 && line.indexOf("port") == -1)
+                    if (!line.contains("unrecognized") && !line.contains("port"))
                         System.err.println(command + ": " + line);
                 }
             } catch (IOException ioException) {

--- a/src/main/java/org/schemaspy/util/Dot.java
+++ b/src/main/java/org/schemaspy/util/Dot.java
@@ -46,7 +46,7 @@ public class Dot {
     private final Set<String> validatedRenderers = Collections.synchronizedSet(new HashSet<String>());
     private final Set<String> invalidatedRenderers = Collections.synchronizedSet(new HashSet<String>());
 
-    private final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private static final String CAIRO_RENDERER = ":cairo";
     private static final String GD_RENDERER = ":gd";
@@ -234,7 +234,7 @@ public class Dot {
             }
             process.waitFor();
         } catch (Exception exc) {
-            exc.printStackTrace();
+            LOGGER.error("Error determining if a renderer is supported",exc);
         }
 
         if (!validatedRenderers.contains(renderer)) {
@@ -355,13 +355,9 @@ public class Dot {
                         System.err.println(command + ": " + line);
                 }
             } catch (IOException ioException) {
-                ioException.printStackTrace();
+                LOGGER.error("Error reading from process",ioException);
             } finally {
-                try {
-                    processReader.close();
-                } catch (Exception exc) {
-                    exc.printStackTrace(); // shouldn't ever get here...but...
-                }
+                IOUtils.closeQuietly(processReader);
             }
         }
     }

--- a/src/main/java/org/schemaspy/util/GraphvizVersion.java
+++ b/src/main/java/org/schemaspy/util/GraphvizVersion.java
@@ -44,7 +44,7 @@ public class GraphvizVersion implements Comparable<GraphvizVersion> {
             while (tokenizer.hasMoreTokens()) {
                 Integer segment = new Integer(tokenizer.nextToken());
                 segments.add(segment);
-                hash += segment.intValue();
+                hash += segment;
             }
         }
 

--- a/src/main/java/org/schemaspy/util/LineWriter.java
+++ b/src/main/java/org/schemaspy/util/LineWriter.java
@@ -40,7 +40,7 @@ public class LineWriter extends BufferedWriter {
         this(new FileOutputStream(file), charset);
     }
 
-    public LineWriter(File file, int sz, String charset) throws UnsupportedEncodingException, IOException {
+    public LineWriter(File file, int sz, String charset) throws IOException {
         this(new FileOutputStream(file), sz, charset);
     }
 

--- a/src/main/java/org/schemaspy/util/Markdown.java
+++ b/src/main/java/org/schemaspy/util/Markdown.java
@@ -36,7 +36,7 @@ public class Markdown {
     }
 
     private static String addReferenceLink(String markdownText, String rootPath) {
-        String text = markdownText;
+        StringBuilder text = new StringBuilder(markdownText);
         String newLine = "\r\n";
 
         Pattern p = Pattern.compile("\\[(.*?)\\]");
@@ -49,7 +49,7 @@ public class Markdown {
         }
 
         if (!links.isEmpty()) {
-            text = text + newLine + newLine;
+            text.append(newLine).append(newLine);
         }
 
         for (String link : links) {
@@ -63,14 +63,12 @@ public class Markdown {
             }
 
             String path = rootPath+pagePath(pageLink);
-            if (path != null) {
-                if (anchorLink != "") {
-                    path = path + "#" + anchorLink;
-                }
-                text = text + "[" +link+ "]: ./" + path + newLine;
-            }
+            if (!anchorLink.equals("")) {
+				path = path + "#" + anchorLink;
+			}
+            text.append("[").append(link).append("]: ./").append(path).append(newLine);
         }
 
-        return text;
+        return text.toString();
     }
 }

--- a/src/main/java/org/schemaspy/view/DefaultSqlFormatter.java
+++ b/src/main/java/org/schemaspy/view/DefaultSqlFormatter.java
@@ -240,8 +240,8 @@ public class DefaultSqlFormatter implements SqlFormatter {
                     meta.getStringFunctions(),
                     meta.getTimeDateFunctions()
                 };
-                for (int i = 0; i < keywordsArray.length; ++i) {
-                    StringTokenizer tokenizer = new StringTokenizer(keywordsArray[i].toUpperCase(), ",");
+                for (String aKeywordsArray : keywordsArray) {
+                    StringTokenizer tokenizer = new StringTokenizer(aKeywordsArray.toUpperCase(), ",");
 
                     while (tokenizer.hasMoreTokens()) {
                         keywords.add(tokenizer.nextToken().trim());

--- a/src/main/java/org/schemaspy/view/HtmlMainIndexPage.java
+++ b/src/main/java/org/schemaspy/view/HtmlMainIndexPage.java
@@ -78,7 +78,7 @@ public class HtmlMainIndexPage extends HtmlFormatter {
         }
 
         long tablesAmount = tables.stream().filter(t -> !t.isView()).count();
-        long viewsAmount = tables.stream().filter(v -> v.isView()).count();
+        long viewsAmount = tables.stream().filter(Table::isView).count();
         long constraintsAmount = DbAnalyzer.getForeignKeyConstraints(tables).size();
 
         HashMap<String, Object> scopes = new HashMap<String, Object>();

--- a/src/main/java/org/schemaspy/view/HtmlTableDiagrammer.java
+++ b/src/main/java/org/schemaspy/view/HtmlTableDiagrammer.java
@@ -20,13 +20,17 @@ package org.schemaspy.view;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 
 import org.schemaspy.model.Table;
 import org.schemaspy.util.DiagramUtil;
 import org.schemaspy.util.Dot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HtmlTableDiagrammer extends HtmlDiagramFormatter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static HtmlTableDiagrammer instance = new HtmlTableDiagrammer();
 
     private HtmlTableDiagrammer() {
@@ -56,11 +60,8 @@ public class HtmlTableDiagrammer extends HtmlDiagramFormatter {
             DiagramUtil.generateDiagram("One implied", dot, oneImpliedDotFile, oneImpliedDiagramFile, diagrams, false, true);
             DiagramUtil.generateDiagram("Two implied", dot, twoImpliedDotFile, twoImpliedDiagramFile, diagrams, false, true);
 
-        } catch (Dot.DotFailure dotFailure) {
-            System.err.println(dotFailure);
-            return false;
-        } catch (IOException ioExc) {
-            ioExc.printStackTrace();
+        } catch (IOException dotFailure) {
+            LOGGER.error("There was an error writing a dot file",dotFailure);
             return false;
         }
 

--- a/src/main/java/org/schemaspy/view/MustacheTableIndex.java
+++ b/src/main/java/org/schemaspy/view/MustacheTableIndex.java
@@ -17,7 +17,7 @@ public class MustacheTableIndex {
     }
 
     public String getKey() {
-        String keyType = "";
+        String keyType;
 
         if (index.isPrimaryKey()) {
             keyType = " class='primaryKey' title='Primary Key'";

--- a/src/test/java/org/schemaspy/model/CatalogTest.java
+++ b/src/test/java/org/schemaspy/model/CatalogTest.java
@@ -1,0 +1,29 @@
+package org.schemaspy.model;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CatalogTest {
+
+	@Test
+	public void compareEqualsHash() {
+		Catalog cat1 = new Catalog("123");
+		Catalog cat2 = new Catalog("456");
+
+		assertThat(cat1).isNotEqualTo(cat2);
+		assertThat(cat1.hashCode()).isNotEqualTo(cat2.hashCode());
+		assertThat(cat1.compareTo(cat2)).isLessThan(0);
+	}
+
+	@Test
+	public void equal() {
+		Catalog cat1 = new Catalog("123");
+		Catalog cat2 = new Catalog("123");
+
+		assertThat(cat1).isEqualTo(cat2);
+		assertThat(cat1.hashCode()).isEqualTo(cat2.hashCode());
+		assertThat(cat1.compareTo(cat2)).isEqualTo(0);
+	}
+
+}

--- a/src/test/java/org/schemaspy/model/CatalogTest.java
+++ b/src/test/java/org/schemaspy/model/CatalogTest.java
@@ -1,5 +1,6 @@
 package org.schemaspy.model;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,22 +9,6 @@ public class CatalogTest {
 
 	@Test
 	public void compareEqualsHash() {
-		Catalog cat1 = new Catalog("123");
-		Catalog cat2 = new Catalog("456");
-
-		assertThat(cat1).isNotEqualTo(cat2);
-		assertThat(cat1.hashCode()).isNotEqualTo(cat2.hashCode());
-		assertThat(cat1.compareTo(cat2)).isLessThan(0);
+		EqualsVerifier.forClass(Catalog.class).withNonnullFields("name").withIgnoredFields("comment").verify();
 	}
-
-	@Test
-	public void equal() {
-		Catalog cat1 = new Catalog("123");
-		Catalog cat2 = new Catalog("123");
-
-		assertThat(cat1).isEqualTo(cat2);
-		assertThat(cat1.hashCode()).isEqualTo(cat2.hashCode());
-		assertThat(cat1.compareTo(cat2)).isEqualTo(0);
-	}
-
 }

--- a/src/test/java/org/schemaspy/model/SchemaTest.java
+++ b/src/test/java/org/schemaspy/model/SchemaTest.java
@@ -1,0 +1,11 @@
+package org.schemaspy.model;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Test;
+
+public class SchemaTest {
+	@Test
+	public void compareEqualsHash() {
+		EqualsVerifier.forClass(Schema.class).withNonnullFields("name").withIgnoredFields("comment").verify();
+	}
+}

--- a/src/test/java/org/schemaspy/model/TableIndexTest.java
+++ b/src/test/java/org/schemaspy/model/TableIndexTest.java
@@ -1,0 +1,88 @@
+package org.schemaspy.model;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TableIndexTest {
+
+	TableIndex tableIndex1;
+	TableIndex tableIndex2;
+
+	@Before
+	public void setup() {
+		tableIndex1 = new TableIndex("index1", false);
+		tableIndex2 = new TableIndex("index2", false);
+	}
+
+	@Test
+	public void primaryKeysSortBeforeNonPrimaryKeys() {
+		tableIndex1.setIsPrimaryKey(true);
+		tableIndex2.setIsPrimaryKey(false);
+
+		assertThat(tableIndex1.compareTo(tableIndex2)).isEqualTo(-1);
+		assertThat(tableIndex2.compareTo(tableIndex1)).isEqualTo(1);
+	}
+
+	@Test
+	public void stringIdComparison() {
+		tableIndex1.setId("a");
+		tableIndex2.setId("b");
+
+		assertThat(tableIndex1.compareTo(tableIndex2)).isEqualTo(-1);
+		assertThat(tableIndex2.compareTo(tableIndex1)).isEqualTo(1);
+	}
+
+	@Test
+	public void numericIdComparison() {
+		tableIndex1.setId(1);
+		tableIndex2.setId(3);
+
+		assertThat(tableIndex1.compareTo(tableIndex2)).isEqualTo(-2);
+		assertThat(tableIndex2.compareTo(tableIndex1)).isEqualTo(2);
+	}
+
+	@Test
+	public void nameComparison() {
+		assertThat(tableIndex1.compareTo(tableIndex2)).isEqualTo(-1);
+		assertThat(tableIndex2.compareTo(tableIndex1)).isEqualTo(1);
+	}
+
+	@Test
+	public void stringIdEquality() {
+		tableIndex1.setId("a");
+		tableIndex2.setId("a");
+
+		assertThat(tableIndex1).isEqualTo(tableIndex2);
+
+		tableIndex2.setId("b");
+		assertThat(tableIndex1).isNotEqualTo(tableIndex2);
+	}
+
+	@Test
+	public void numericIdEquality() {
+		tableIndex1.setId(1);
+		tableIndex2.setId(1);
+
+		assertThat(tableIndex1).isEqualTo(tableIndex2);
+		assertThat(tableIndex1.hashCode()).isEqualTo(tableIndex2.hashCode());
+
+		tableIndex2.setId(2);
+		assertThat(tableIndex1).isNotEqualTo(tableIndex2);
+		assertThat(tableIndex1.hashCode()).isNotEqualTo(tableIndex2.hashCode());
+	}
+
+	@Test
+	public void nameEquality() {
+		tableIndex1 = new TableIndex("name", false);
+		tableIndex2 = new TableIndex("name", false);
+		assertThat(tableIndex1).isEqualTo(tableIndex2);
+		assertThat(tableIndex1.hashCode()).isEqualTo(tableIndex2.hashCode());
+
+		tableIndex2 = new TableIndex("name2", false);
+		assertThat(tableIndex1).isNotEqualTo(tableIndex2);
+		assertThat(tableIndex1.hashCode()).isNotEqualTo(tableIndex2.hashCode());
+	}
+
+}


### PR DESCRIPTION
Most of these fix some sonar warnings
* Replace most printStackTrace() calls to use a logger - a few remain, they are grouped with a bunch of other System.out lines
* Remove some dead stores that were put in there a long time ago to "allow GC ASAP"
* Several classes had compareTo methods, but no equals / hashcode
* Switched a manual null check in a constructor to use `Objects.requireNonNull`
* There were a few uses of string concatenation inside of a loop, which isn't as efficient as allocating a StringBuilder (sonar  squid:S1643)

Fix the following IntelliJ warnings:
* for loop replaceable with foreach
* indexOf expression is replaceable with contains
* unnecessary boxing
* unnecessary unboxing
* Collections.sort could be replaced with List.sort
* Lambda can be replaced with method reference
* Duplicate throws