### PR TITLE
Exclude index column with ordinal 0

### DIFF
--- a/docs/source/configuration/databaseType.rst
+++ b/docs/source/configuration/databaseType.rst
@@ -136,6 +136,8 @@ So additional columns are ok, but you might need to alias columns so that they a
         table_name, table_catalog, table_schema, table_comment, table_rows
     **selectViewsSql=**
         view_name, view_catalog, view_schema, view_comment, view_definition
+    **selectIndexesSql=**
+        INDEX_NAME, TYPE, NON_UNIQUE, COLUMN_NAME, ASC_OR_DESC
     **selectRowCountSql=**
         row_count
     **selectColumnTypesSql=**

--- a/src/main/java/org/schemaspy/service/TableService.java
+++ b/src/main/java/org/schemaspy/service/TableService.java
@@ -563,13 +563,20 @@ public class TableService {
         try (ResultSet rs = db.getMetaData().getIndexInfo(table.getCatalog(), table.getSchema(), table.getName(), false, true)){
 
             while (rs.next()) {
-                if (rs.getShort("TYPE") != DatabaseMetaData.tableIndexStatistic)
+                if (isIndexRow(rs))
                     addIndex(table, rs);
             }
         } catch (SQLException exc) {
             if (!table.isLogical())
                 LOGGER.warn("Unable to extract index info for table '{}' in schema '{}': {}", table.getName(), table.getContainer(), exc);
         }
+    }
+
+    //This is to handle a problem with informix and lvarchar Issue 215. It's been reported to IBM.
+    //According to DatabaseMetaData.getIndexInfo() ORDINAL_POSITION is zero when type is tableIndexStatistic.
+    //Problem with informix is that lvarchar is reported back as TYPE = tableIndexOther and ORDINAL_POSITION = 0.
+    private boolean isIndexRow(ResultSet rs) throws SQLException {
+        return rs.getShort("TYPE") != DatabaseMetaData.tableIndexStatistic && rs.getShort("ORDINAL_POSITION") > 0;
     }
 
     /**

--- a/src/test/java/org/schemaspy/service/TableServiceTest.java
+++ b/src/test/java/org/schemaspy/service/TableServiceTest.java
@@ -1,0 +1,72 @@
+package org.schemaspy.service;
+
+import org.junit.Test;
+import org.schemaspy.cli.CommandLineArguments;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TableServiceTest {
+
+    private SqlService sqlService = mock(SqlService.class);
+    private CommandLineArguments commandLineArguments = mock(CommandLineArguments.class);
+
+    private TableService tableService = new TableService(sqlService,commandLineArguments);
+
+    private Supplier<Method> isIndexRowMethod = () -> {
+        Method m = null;
+        try {
+            m = TableService.class.getDeclaredMethod("isIndexRow", ResultSet.class);
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        }
+        m.setAccessible(true);
+        Method finalM = m;
+        isIndexRowMethod = () -> finalM;
+        return m;
+    };
+
+    private boolean isIndexRow(ResultSet rs) throws InvocationTargetException, IllegalAccessException {
+        return (Boolean)isIndexRowMethod.get().invoke(tableService, rs);
+    }
+
+    private ResultSet newResultSet(short type, int ordinal) throws SQLException {
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.getShort("TYPE")).thenReturn(type);
+        when(rs.getShort("ORDINAL_POSITION")).thenReturn((short) ordinal);
+        return rs;
+    }
+
+    @Test
+    public void TableStatAndOrdinalZeroIsNotIndexRow() throws InvocationTargetException, IllegalAccessException, SQLException {
+        ResultSet rs = newResultSet(DatabaseMetaData.tableIndexStatistic, 0);
+        assertThat(isIndexRow(rs)).isFalse();
+    }
+
+    @Test
+    public void NotTableStatAndOrdinalZeroIsNotIndexRow() throws SQLException, InvocationTargetException, IllegalAccessException {
+        ResultSet rs = newResultSet(DatabaseMetaData.tableIndexClustered, 0);
+        assertThat(isIndexRow(rs)).isFalse();
+    }
+
+    @Test
+    public void TableStatAndOrdinalNotZeroIsNotIndexRow() throws SQLException, InvocationTargetException, IllegalAccessException {
+        ResultSet rs = newResultSet(DatabaseMetaData.tableIndexStatistic, 10);
+        assertThat(isIndexRow(rs)).isFalse();
+    }
+
+    @Test
+    public void NotTableStatsAndOrdinalNotZeroIsIndexRow() throws SQLException, InvocationTargetException, IllegalAccessException {
+        ResultSet rs = newResultSet(DatabaseMetaData.tableIndexClustered,10);
+        assertThat(isIndexRow(rs)).isTrue();
+    }
+
+}


### PR DESCRIPTION
Would be a fix for #215 but since It's a JDBC issue and it's reported to IBM.

This might not be wanted.