### PR TITLE
Add validation that resource found in PropertiesFinder is a file

### DIFF
--- a/docs/source/configuration/databaseType.rst
+++ b/docs/source/configuration/databaseType.rst
@@ -8,6 +8,8 @@ Selection
 
 On the commandline you specify the databaseType using the option ``-t``.
 The option can be specified with either [name].properties or just [name]
+the .properties will be added if missing. So if you create one, be sure
+to have .properties extension.
 
 Example:
  ``-t mysql``
@@ -15,22 +17,16 @@ or
  ``-t mysql.properties``
 
 The search order is:
-    1. user.dir/ as supplied
-    2. user.dir/ as supplied, suffixed with .properties
-    3. Classpath as supplied
-    4. Classpath as supplied, suffixed with .properties
-    5. Classpath in schemaspy supplied location as supplied
-    6. Classpath in schemaspy supplied location as supplied, suffixed with .properties
+    1. user.dir/
+    2. Classpath
+    3. Classpath in schemaspy supplied location
 
 This actually means that if you supply ``-t my_conf/mydbtype``
 
 It will look for:
-    1. file: $user.dir/my_conf/mydbtype
-    2. file: $user.dir/my_conf/mydbtype.properties
-    3. Classpath: my_conf/mydbtype
-    4. Classpath: my_conf/mydbtype.properties
-    5. Classpath: org/schemaspy/types/my_conf/mydbtype
-    6. Classpath: org/schemaspy/types/my_conf/mydbtype.properties
+    1. file: $user.dir/my_conf/mydbtype.properties
+    2. Classpath: my_conf/mydbtype.properties
+    3. Classpath: org/schemaspy/types/my_conf/mydbtype.properties
 
 Layout
 ------

--- a/docs/source/configuration/schemaMeta.rst
+++ b/docs/source/configuration/schemaMeta.rst
@@ -1,7 +1,7 @@
 SchemaMeta
 ==========
 
-Is a way to modify the processing in and output from SchemaSpy.
+Is a way to modify input that will affect output from SchemaSpy.
 
     * :ref:`schemameta-comment`
     * :ref:`schemameta-add-foreignKey`

--- a/src/main/java/org/schemaspy/db/config/PropertiesFinder.java
+++ b/src/main/java/org/schemaspy/db/config/PropertiesFinder.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -21,24 +22,15 @@ public class PropertiesFinder implements ResourceFinder {
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private static final String DB_TYPES_LOCATION = "org/schemaspy/types/";
-    private static final String DOT_PROPERTIES = ".properties";
 
-    public URL find(String dbType) {
-        URL url = findFile(dbType);
+    public URL find(final String dbType) {
+        String dbTypeToFind = addExtensionIfMissing(dbType);
+        URL url = findFile(dbTypeToFind);
         if (Objects.isNull(url)) {
-            url = findFile(dbType + DOT_PROPERTIES);
+            url = findClassPath(dbTypeToFind);
         }
         if (Objects.isNull(url)) {
-            url = findClassPath(dbType);
-        }
-        if (Objects.isNull(url)) {
-            url = findClassPath(dbType + DOT_PROPERTIES);
-        }
-        if (Objects.isNull(url)) {
-            url = findClassPath(DB_TYPES_LOCATION + dbType);
-        }
-        if (Objects.isNull(url)) {
-            url = findClassPath(DB_TYPES_LOCATION + dbType + DOT_PROPERTIES);
+            url = findClassPath(DB_TYPES_LOCATION + dbTypeToFind);
         }
         if (Objects.isNull(url)) {
             throw new ResourceNotFoundException(dbType);
@@ -46,9 +38,13 @@ public class PropertiesFinder implements ResourceFinder {
         return url;
     }
 
+    private String addExtensionIfMissing(String dbType) {
+        return dbType.toLowerCase().endsWith(".properties") ? dbType : dbType + ".properties";
+    }
+
     private URL findFile(String file) {
         Path path = Paths.get(file);
-        if (path.toFile().exists()) {
+        if (path.toFile().exists() && path.toFile().isFile()) {
             try {
                 return path.toUri().toURL();
             } catch (MalformedURLException e) {
@@ -60,6 +56,15 @@ public class PropertiesFinder implements ResourceFinder {
     }
 
     private URL findClassPath(String resource) {
-        return this.getClass().getClassLoader().getResource(resource);
+        URL url = this.getClass().getClassLoader().getResource(resource);
+        try {
+            if (Objects.nonNull(url) && Paths.get(url.toURI()).toFile().isFile()) {
+                return url;
+            }
+        } catch (URISyntaxException e) {
+            LOGGER.debug("Couldn't convert url to uri to file: {}", url, e);
+            return null;
+        }
+        return null;
     }
 }

--- a/src/test/java/org/schemaspy/db/config/PropertiesFinderTest.java
+++ b/src/test/java/org/schemaspy/db/config/PropertiesFinderTest.java
@@ -5,7 +5,9 @@ package org.schemaspy.db.config;
 
 import org.junit.Test;
 
+import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,12 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class PropertiesFinderTest {
 
     private PropertiesFinder propertiesFinder = new PropertiesFinder();
-
-    @Test
-    public void findOnClassPathWithoutExtension() {
-        URL url = propertiesFinder.find("E0");
-        assertThat(url).isNotNull();
-    }
 
     @Test
     public void findOnClassPathWithExtension() {
@@ -45,14 +41,20 @@ public class PropertiesFinderTest {
         assertThat(url).isNotNull();
     }
 
-    @Test
-    public void findByPathHasNoExtension() {
-        URL url = propertiesFinder.find("src/test/resources/dbtypes/D0");
-        assertThat(url).isNotNull();
-    }
-
     @Test(expected = ResourceNotFoundException.class)
     public void noSuchResource() {
         propertiesFinder.find("doesNotExist");
+    }
+
+    @Test
+    public void shouldNotReturnAFolderFromClassPath() throws URISyntaxException {
+        URL url = propertiesFinder.find("folder");
+        assertThat(Paths.get(url.toURI()).toFile().isDirectory()).isFalse();
+    }
+
+    @Test
+    public void shouldNotReturnAFolderFromPath() throws URISyntaxException {
+        URL url = propertiesFinder.find("src/test/resources/org/schemaspy/types/folder");
+        assertThat(Paths.get(url.toURI()).toFile().isDirectory()).isFalse();
     }
 }

--- a/src/test/resources/dbtypes/D0
+++ b/src/test/resources/dbtypes/D0
@@ -1,4 +1,0 @@
-level=0
-branch=D
-level0=zero
-dvalue=This is branch D

--- a/src/test/resources/org/schemaspy/types/E0
+++ b/src/test/resources/org/schemaspy/types/E0
@@ -1,4 +1,0 @@
-level=0
-branch=E
-level0=zero
-evalue=This is branch E

--- a/src/test/resources/org/schemaspy/types/folder.properties
+++ b/src/test/resources/org/schemaspy/types/folder.properties
@@ -1,0 +1,1 @@
+this=is the properties file and not the folder


### PR DESCRIPTION
* Removed the possibility of reading files without extension.
  We just add .properties if it's missing. Update docs.
* Fixed a wording issue in schemameta docs.

Fixes #229 