### PR TITLE
Adding build info and removing buildNumber.properties

### DIFF
--- a/buildNumber.properties
+++ b/buildNumber.properties
@@ -1,3 +1,0 @@
-#maven.buildNumber.plugin properties file
-#Tue Dec 12 15:37:44 CST 2017
-buildNumber=40

--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,17 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
         <sonar.junit.reportPaths>target/surefire-reports,target/failsafe-reports</sonar.junit.reportPaths>
 
         <spring-boot.version>1.5.9.RELEASE</spring-boot.version>
 
         <java.version>1.8</java.version>
+
+        <maven.buildNumber.timestampFormat>{0,date,yyyy-MM-dd HH:mm:ssX}</maven.buildNumber.timestampFormat>
+        <maven.buildNumber.useLastCommittedRevision>false</maven.buildNumber.useLastCommittedRevision>
+        <maven.buildNumber.shortRevisionLength>7</maven.buildNumber.shortRevisionLength>
+        <maven.buildNumber.revisionOnScmFailure>unknown</maven.buildNumber.revisionOnScmFailure>
     </properties>
     <issueManagement>
         <url>https://github.com/schemaspy/schemaspy/issues</url>
@@ -243,6 +249,15 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>1.4</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -251,8 +266,13 @@
                 <configuration>
                     <archive>
                         <manifestEntries>
+                            <Implementation-Title>SchemaSpy</Implementation-Title>
                             <Implementation-Version>${project.version}</Implementation-Version>
-                            <Implementation-Build>${buildNumber}</Implementation-Build>
+                            <Implementation-URL>http://schemaspy.org</Implementation-URL>
+                            <Implementation-Build>${project.version} #${buildNumber} - ${timestamp}</Implementation-Build>
+                            <Built-Branch>${scmBranch}</Built-Branch>
+                            <Built-Revision>${buildNumber}</Built-Revision>
+                            <Built-At>${timestamp}</Built-At>
                         </manifestEntries>
                     </archive>
                 </configuration>
@@ -282,7 +302,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>1.4</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -292,12 +311,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <doCheck>true</doCheck>
-                    <format>${project.version}.{0,number} {1,date,yyyy-MM-dd HH:mm:ss}</format>
-                    <items>
-                        <item>buildNumber</item>
-                        <item>timestamp</item>
-                    </items>
+                    <doCheck>false</doCheck>
                 </configuration>
             </plugin>
             <plugin>
@@ -352,6 +366,9 @@
                     <value>true</value>
                 </property>
             </activation>
+            <properties>
+                <maven.buildNumber.doCheck>true</maven.buildNumber.doCheck>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/src/main/java/org/schemaspy/BuildInfo.java
+++ b/src/main/java/org/schemaspy/BuildInfo.java
@@ -1,0 +1,68 @@
+package org.schemaspy;
+
+import org.schemaspy.util.JarFileFinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.jar.Attributes;
+import java.util.jar.Attributes.Name;
+import java.util.jar.JarFile;
+
+@Component
+public class BuildInfo {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final JarFileFinder jarFileFinder = new JarFileFinder();
+
+    private static final String UNKNOWN = "Unknown";
+
+    private static final Name VERSION = new Name("Implementation-Version");
+    private static final Name REVISION = new Name("Built-Revision");
+    private static final Name BRANCH = new Name("Built-Branch");
+    private static final Name BY = new Name("Built-By");
+    private static final Name JDK = new Name("Build-Jdk");
+    private static final Name BUILD_TIME = new Name("Built-At");
+
+    private Attributes attributes;
+
+    public BuildInfo() {
+        try (JarFile jarFile = jarFileFinder.findJarFileForClass(this.getClass())){
+            attributes = jarFile.getManifest().getMainAttributes();
+        } catch (IOException e) {
+            attributes = new Attributes();
+            LOGGER.error("Failed to load attributes from manifest", e);
+        }
+    }
+
+    public String getVersion() {
+        return get(VERSION);
+    }
+
+    public String getRevision() {
+        return get(REVISION);
+    }
+
+    public String getBranch() {
+        return get(BRANCH);
+    }
+
+    public String getBuilder() {
+        return get(BY);
+    }
+
+    public String getJDK() {
+        return get(JDK);
+    }
+
+    public String getBuildTime() {
+        return get(BUILD_TIME);
+    }
+
+    private String get(Name name) {
+        return (String) attributes.getOrDefault(name, UNKNOWN);
+    }
+
+}

--- a/src/main/java/org/schemaspy/BuildInfo.java
+++ b/src/main/java/org/schemaspy/BuildInfo.java
@@ -33,7 +33,7 @@ public class BuildInfo {
             attributes = jarFile.getManifest().getMainAttributes();
         } catch (IOException e) {
             attributes = new Attributes();
-            LOGGER.error("Failed to load attributes from manifest", e);
+            LOGGER.warn("Failed to load attributes from manifest", e);
         }
     }
 

--- a/src/main/java/org/schemaspy/BuildInfo.java
+++ b/src/main/java/org/schemaspy/BuildInfo.java
@@ -1,6 +1,7 @@
 package org.schemaspy;
 
 import org.schemaspy.util.JarFileFinder;
+import org.schemaspy.util.NotRunningFromJarException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -27,6 +28,7 @@ public class BuildInfo {
     private static final Name BUILD_TIME = new Name("Built-At");
 
     private Attributes attributes;
+    private String defaultValue = UNKNOWN;
 
     public BuildInfo() {
         try (JarFile jarFile = jarFileFinder.findJarFileForClass(this.getClass())){
@@ -34,6 +36,9 @@ public class BuildInfo {
         } catch (IOException e) {
             attributes = new Attributes();
             LOGGER.warn("Failed to load attributes from manifest", e);
+        } catch (NotRunningFromJarException notJar) {
+            attributes = new Attributes();
+            defaultValue = "NonBuild";
         }
     }
 
@@ -62,7 +67,7 @@ public class BuildInfo {
     }
 
     private String get(Name name) {
-        return (String) attributes.getOrDefault(name, UNKNOWN);
+        return (String) attributes.getOrDefault(name, defaultValue);
     }
 
 }

--- a/src/main/java/org/schemaspy/Main.java
+++ b/src/main/java/org/schemaspy/Main.java
@@ -52,7 +52,11 @@ public class Main implements CommandLineRunner {
     @Autowired
     private ApplicationContext context;
 
+    @Autowired
+    private BuildInfo buildInfo;
+
     public static void main(String... args) {
+        LogLevelConditionalThrowableProxyConverter.register();
         SpringApplication.run(Main.class, args);
     }
 
@@ -66,6 +70,16 @@ public class Main implements CommandLineRunner {
 
         if (arguments.isDbHelpRequired()) {
             commandLineArgumentParser.printDatabaseTypesHelp();
+            exitApplication(0);
+            return;
+        }
+
+        if (arguments.isShowVersionInfo()) {
+            LOGGER.info("Version: " + buildInfo.getVersion());
+            LOGGER.info("Branch: " + buildInfo.getBranch());
+            LOGGER.info("Revision: " + buildInfo.getRevision());
+            LOGGER.info("JDK: " + buildInfo.getJDK());
+            LOGGER.info("Build time: " + buildInfo.getBuildTime());
             exitApplication(0);
             return;
         }

--- a/src/main/java/org/schemaspy/Main.java
+++ b/src/main/java/org/schemaspy/Main.java
@@ -56,7 +56,6 @@ public class Main implements CommandLineRunner {
     private BuildInfo buildInfo;
 
     public static void main(String... args) {
-        LogLevelConditionalThrowableProxyConverter.register();
         SpringApplication.run(Main.class, args);
     }
 

--- a/src/main/java/org/schemaspy/Revision.java
+++ b/src/main/java/org/schemaspy/Revision.java
@@ -21,6 +21,7 @@
 package org.schemaspy;
 
 import org.schemaspy.util.JarFileFinder;
+import org.schemaspy.util.NotRunningFromJarException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +50,8 @@ public class Revision {
 			rev = (String) main.getOrDefault(new Attributes.Name("Implementation-Build"),"Unknown");
 		} catch (IOException ex) {
 			LOGGER.warn(ex.getMessage(), ex);
+		} catch (NotRunningFromJarException notRunningFromJar) {
+			rev = "NonBuild";
 		}
 	}
 

--- a/src/main/java/org/schemaspy/Revision.java
+++ b/src/main/java/org/schemaspy/Revision.java
@@ -48,7 +48,7 @@ public class Revision {
 			Attributes main     = jarFile.getManifest().getMainAttributes();
 			rev = (String) main.getOrDefault(new Attributes.Name("Implementation-Build"),"Unknown");
 		} catch (IOException ex) {
-			LOGGER.error(ex.getMessage(), ex);
+			LOGGER.warn(ex.getMessage(), ex);
 		}
 	}
 

--- a/src/main/java/org/schemaspy/Revision.java
+++ b/src/main/java/org/schemaspy/Revision.java
@@ -1,6 +1,8 @@
 /*
+ * Copyright (C) 2004-2011 John Currier
+ * Copyright (C) 2018 Nils Petzaell
+ *
  * This file is a part of the SchemaSpy project (http://schemaspy.org).
- * Copyright (C) 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011 John Currier
  *
  * SchemaSpy is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -18,32 +20,34 @@
  */
 package org.schemaspy;
 
+import org.schemaspy.util.JarFileFinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.InputStream;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.jar.Attributes;
-import java.util.jar.Manifest;
+import java.util.jar.JarFile;
 
 /**
  * @author John Currier
+ * @author Nils Petzaell
  */
 public class Revision {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-	private static       String rev          = "Unknown";
-	private static final String RESOURCE_NAME = "/META-INF/MANIFEST.MF";
+    private static final JarFileFinder jarFileFinder = new JarFileFinder();
+
+	private static String rev          = "Unknown";
 
 	static {
 		initialize();
 	}
 
 	private static void initialize() {
-		try (InputStream in = Revision.class.getResourceAsStream(RESOURCE_NAME)) {
-			Manifest   manifest = new Manifest(in);
-			Attributes main     = manifest.getMainAttributes();
-			rev = (String) main.getOrDefault("Implementation-Build","Unknown");
-		} catch (Exception ex) {
+		try (JarFile jarFile = jarFileFinder.findJarFileForClass(Revision.class)) {
+			Attributes main     = jarFile.getManifest().getMainAttributes();
+			rev = (String) main.getOrDefault(new Attributes.Name("Implementation-Build"),"Unknown");
+		} catch (IOException ex) {
 			LOGGER.error(ex.getMessage(), ex);
 		}
 	}

--- a/src/main/java/org/schemaspy/cli/CommandLineArguments.java
+++ b/src/main/java/org/schemaspy/cli/CommandLineArguments.java
@@ -55,6 +55,13 @@ public class CommandLineArguments {
     private boolean debug = false;
 
     @Parameter(
+            names = {"-version-info"},
+            help = true,
+            descriptionKey = "version-info"
+    )
+    private boolean showVersionInfo = false;
+
+    @Parameter(
             names = {
                     "-t", "--database-type", "database-type",
                     "schemaspy.t", "schemaspy.database-type"
@@ -155,6 +162,10 @@ public class CommandLineArguments {
 
     public boolean isDebug() {
         return debug;
+    }
+
+    public boolean isShowVersionInfo() {
+        return showVersionInfo;
     }
 
     public String getDatabaseType() {

--- a/src/main/java/org/schemaspy/util/JarFileFinder.java
+++ b/src/main/java/org/schemaspy/util/JarFileFinder.java
@@ -1,0 +1,20 @@
+package org.schemaspy.util;
+
+import java.io.IOException;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.jar.JarFile;
+
+public class JarFileFinder {
+
+    public JarFile findJarFileForClass(Class cls) throws IOException {
+        URL location = cls.getProtectionDomain().getCodeSource().getLocation();
+        URLConnection urlConnection = location.openConnection();
+        if (urlConnection instanceof JarURLConnection) {
+            return ((JarURLConnection)urlConnection).getJarFile();
+        } else {
+            return new JarFile(location.getPath());
+        }
+    }
+}

--- a/src/main/java/org/schemaspy/util/JarFileFinder.java
+++ b/src/main/java/org/schemaspy/util/JarFileFinder.java
@@ -14,7 +14,11 @@ public class JarFileFinder {
         if (urlConnection instanceof JarURLConnection) {
             return ((JarURLConnection)urlConnection).getJarFile();
         } else {
-            return new JarFile(location.getPath());
+            try {
+                return new JarFile(location.getPath());
+            } catch (IOException e) {
+                throw new NotRunningFromJarException(location.getPath(), e);
+            }
         }
     }
 }

--- a/src/main/java/org/schemaspy/util/NotRunningFromJarException.java
+++ b/src/main/java/org/schemaspy/util/NotRunningFromJarException.java
@@ -1,0 +1,9 @@
+package org.schemaspy.util;
+
+import java.io.IOException;
+
+public class NotRunningFromJarException extends RuntimeException {
+    public NotRunningFromJarException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/src/main/resources/commandlinearguments.properties
+++ b/src/main/resources/commandlinearguments.properties
@@ -11,3 +11,4 @@ dbhelp=Show built-in database types and their required connection parameters
 databaseName=Name of database to connect to
 debug=Enable debug logging
 sso=Remove requirement for user
+version-info=Show detailed information about application

--- a/src/test/java/org/schemaspy/BuildInfoTestIT.java
+++ b/src/test/java/org/schemaspy/BuildInfoTestIT.java
@@ -8,36 +8,43 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BuildInfoTestIT {
 
     private static final String UNKNOWN = "Unknown";
+    private static final String NON_BUILD = "NonBuild";
 
     private BuildInfo buildInfo = new BuildInfo();
 
     @Test
     public void getVersion() {
         assertThat(buildInfo.getVersion()).isNotEqualToIgnoringCase(UNKNOWN);
+        assertThat(buildInfo.getVersion()).isNotEqualToIgnoringCase(NON_BUILD);
     }
 
     @Test
     public void getRevision() {
         assertThat(buildInfo.getRevision()).isNotEqualToIgnoringCase(UNKNOWN);
+        assertThat(buildInfo.getRevision()).isNotEqualToIgnoringCase(NON_BUILD);
     }
 
     @Test
     public void getBranch() {
         assertThat(buildInfo.getBranch()).isNotEqualToIgnoringCase(UNKNOWN);
+        assertThat(buildInfo.getBranch()).isNotEqualToIgnoringCase(NON_BUILD);
     }
 
     @Test
     public void getBuilder() {
         assertThat(buildInfo.getBuilder()).isNotEqualToIgnoringCase(UNKNOWN);
+        assertThat(buildInfo.getBuilder()).isNotEqualToIgnoringCase(NON_BUILD);
     }
 
     @Test
     public void getJDK() {
         assertThat(buildInfo.getJDK()).isNotEqualToIgnoringCase(UNKNOWN);
+        assertThat(buildInfo.getJDK()).isNotEqualToIgnoringCase(NON_BUILD);
     }
 
     @Test
     public void getBuildTime() {
         assertThat(buildInfo.getBuildTime()).isNotEqualToIgnoringCase(UNKNOWN);
+        assertThat(buildInfo.getBuildTime()).isNotEqualToIgnoringCase(NON_BUILD);
     }
 }

--- a/src/test/java/org/schemaspy/BuildInfoTestIT.java
+++ b/src/test/java/org/schemaspy/BuildInfoTestIT.java
@@ -1,0 +1,43 @@
+package org.schemaspy;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+//Only works with maven since it adds the original-jar and dependencies to classpath
+public class BuildInfoTestIT {
+
+    private static final String UNKNOWN = "Unknown";
+
+    private BuildInfo buildInfo = new BuildInfo();
+
+    @Test
+    public void getVersion() {
+        assertThat(buildInfo.getVersion()).isNotEqualToIgnoringCase(UNKNOWN);
+    }
+
+    @Test
+    public void getRevision() {
+        assertThat(buildInfo.getRevision()).isNotEqualToIgnoringCase(UNKNOWN);
+    }
+
+    @Test
+    public void getBranch() {
+        assertThat(buildInfo.getBranch()).isNotEqualToIgnoringCase(UNKNOWN);
+    }
+
+    @Test
+    public void getBuilder() {
+        assertThat(buildInfo.getBuilder()).isNotEqualToIgnoringCase(UNKNOWN);
+    }
+
+    @Test
+    public void getJDK() {
+        assertThat(buildInfo.getJDK()).isNotEqualToIgnoringCase(UNKNOWN);
+    }
+
+    @Test
+    public void getBuildTime() {
+        assertThat(buildInfo.getBuildTime()).isNotEqualToIgnoringCase(UNKNOWN);
+    }
+}

--- a/src/test/java/org/schemaspy/RevisionTest.java
+++ b/src/test/java/org/schemaspy/RevisionTest.java
@@ -9,7 +9,7 @@ public class RevisionTest {
     @Test
     public void revisionDefaultsToUnknown() {
         Revision revision = new Revision();
-        assertThat(revision.toString()).isEqualTo("Unknown");
+        assertThat(revision.toString()).isEqualTo("NonBuild");
     }
 
 }

--- a/src/test/java/org/schemaspy/RevisionTestIT.java
+++ b/src/test/java/org/schemaspy/RevisionTestIT.java
@@ -1,0 +1,18 @@
+package org.schemaspy;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+//This will fail in ide but work in maven, since maven uses the built jar on classpath.
+public class RevisionTestIT {
+
+    private Revision revision = new Revision();
+
+    @Test
+    public void isNotUnknown() throws IOException {
+        assertThat(revision.toString()).isNotEqualToIgnoringCase("unknown");
+    }
+}

--- a/src/test/java/org/schemaspy/RevisionTestIT.java
+++ b/src/test/java/org/schemaspy/RevisionTestIT.java
@@ -14,5 +14,6 @@ public class RevisionTestIT {
     @Test
     public void isNotUnknown() throws IOException {
         assertThat(revision.toString()).isNotEqualToIgnoringCase("unknown");
+        assertThat(revision.toString()).isNotEqualToIgnoringCase("NonBuild");
     }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,7 +1,9 @@
 <configuration>
+    <conversionRule conversionWord="debugEx"
+                    converterClass="org.schemaspy.logging.LogLevelConditionalThrowableProxyConverter" />
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n%debugEx</pattern>
         </encoder>
     </appender>
 

--- a/travis.sh
+++ b/travis.sh
@@ -15,7 +15,8 @@ if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
 	echo "Starting analysis by SonarQube..."
 	mvn -P sonar clean verify -e -V \
 		-Dsonar.host.url=$SONAR_HOST_URL \
-		-Dsonar.login=$SONAR_TOKEN
+		-Dsonar.login=$SONAR_TOKEN \
+		-DscmBranch=$TRAVIS_BRANCH
 
 elif [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ -n "${GITHUB_TOKEN-}" ]; then
 	# => This will analyse the PR and display found issues as comments in the PR, but it won't push results to the SonarQube server
@@ -31,10 +32,15 @@ elif [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ -n "${GITHUB_TOKEN-}" ]; then
 		-Dsonar.analysis.mode=preview \
 		-Dsonar.github.oauth=$GITHUB_TOKEN \
 		-Dsonar.github.repository=$TRAVIS_REPO_SLUG \
-		-Dsonar.github.pullRequest=$TRAVIS_PULL_REQUEST
-else
-	echo 'Build feature branch or external pull request'
+		-Dsonar.github.pullRequest=$TRAVIS_PULL_REQUEST \
+		-DscmBranch=$TRAVIS_PULL_REQUEST_BRANCH
 
-    mvn clean -e verify
+elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+    echo 'Build external pull request'
+    mvn -DscmBranch=$TRAVIS_PULL_REQUEST_BRANCH clean -e verify
+
+else
+	echo 'Build feature branch'
+    mvn -DscmBranch=$TRAVIS_BRANCH clean -e verify
 fi
 # When neither on master branch nor on a non-external pull request => nothing to do


### PR DESCRIPTION
* Adding git commit hash instead of a number.
* Added additional information to manifest.
* Added BuildInfo to access manifest attributes.
* Made Revision look in correct jar for manifest.
* Fixed issue with value lookup in Revision getOrDefault expects
  key to be Attributes.Name object.
* Added version-info argument to commandline

Revision now returns 6.0.0-rc2 #46120e0 - 2018-01-25 01:43:01+01
-version-info outputs:
![image](https://user-images.githubusercontent.com/4175123/35365122-185bbb0e-0173-11e8-8b50-4afb2d6e854c.png)
