### PR TITLE
Updates for hive

### DIFF
--- a/src/main/resources/org/schemaspy/types/hive-kerberos-driverwrapper-zookeeper.properties
+++ b/src/main/resources/org/schemaspy/types/hive-kerberos-driverwrapper-zookeeper.properties
@@ -1,7 +1,6 @@
 extends=hive
-description=Hive with keytab support
-connectionSpec=jdbc:hive2://<host>:<port>/<db>;principal=<principal>
-principal=the principal to use
+description=Hive with keytab support configured for service discovery using zookeeper
+connectionSpec=jdbc:hive2://<host>:<port>/<db>;serviceDiscoveryMode=zooKeeper
 
 # There are some distributions and they have multiple different versions.
 # You more or less might need to build your own uber jar

--- a/src/main/resources/org/schemaspy/types/hive-kerberos-driverwrapper.properties
+++ b/src/main/resources/org/schemaspy/types/hive-kerberos-driverwrapper.properties
@@ -1,0 +1,4 @@
+extends=hive
+connectionSpec=jdbc:hive2://<host>:<port>/<db>;principal=<principal>
+principal=the principal to connect with
+driver=com.github.npetzall.hive.kerberos.DriverWrapper

--- a/src/main/resources/org/schemaspy/types/hive.properties
+++ b/src/main/resources/org/schemaspy/types/hive.properties
@@ -1,4 +1,4 @@
-# see http://schemaspy.org/dbtypes.html
+# see http://schemaspy.readthedocs.io/en/latest/configuration.html#databasetype
 # for configuration / customization details
 
 description=Hive
@@ -8,6 +8,7 @@ port=database port
 db=database name
 driver=org.apache.hive.jdbc.HiveDriver
 
-# Sample path to the H2 drivers available at http://www.h2database.com
 # Use -dp to override.
 driverPath=/lib/hive-jdbc-2.1.0.2.6.3.0-235-standalone.jar
+
+tableTypes=TABLES,TABLE,MANAGED_TABLE,EXTERNAL_TABLE


### PR DESCRIPTION
Updated tableTypes for plain hive. Long list due to difference between distributions (cloudera, hdp)

* Added two for kerberized clusters using a driverwrapper, just kerberos and one with discoveryMode=zookeeper