### PR TITLE
Made user argument conditionally required dependent on `-sso`

### DIFF
--- a/src/main/java/org/schemaspy/cli/CommandLineArgumentParser.java
+++ b/src/main/java/org/schemaspy/cli/CommandLineArgumentParser.java
@@ -1,12 +1,16 @@
 package org.schemaspy.cli;
 
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterDescription;
+import com.beust.jcommander.ParameterException;
 import org.schemaspy.Config;
 import org.schemaspy.util.DbSpecificConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
+import java.util.*;
+import java.util.stream.Collectors;
 
 
 /**
@@ -20,17 +24,11 @@ public class CommandLineArgumentParser {
 
     private final PropertyFileDefaultProvider defaultProvider;
 
+    private static final String[] requiredFields = {"outputDirectory"};
+
     public CommandLineArgumentParser(PropertyFileDefaultProvider defaultProvider) {
         this.defaultProvider = defaultProvider;
         jCommander = createJCommander();
-    }
-
-    public CommandLineArguments parse(String... localArgs) {
-        CommandLineArguments arguments = new CommandLineArguments();
-        jCommander.addObject(arguments);
-
-        jCommander.parse(localArgs);
-        return arguments;
     }
 
     private JCommander createJCommander() {
@@ -41,6 +39,55 @@ public class CommandLineArgumentParser {
                 .defaultProvider(defaultProvider)
                 .build();
     }
+
+    public CommandLineArguments parse(String... localArgs) {
+        CommandLineArguments arguments = new CommandLineArguments();
+        jCommander.addObject(arguments);
+
+        jCommander.parse(localArgs);
+
+        validate(arguments);
+        return arguments;
+    }
+
+    private void validate(CommandLineArguments arguments) {
+        List<String> runtimeRequiredFields = computeRequiredFields(arguments);
+
+        List<String> missingFields = new ArrayList<>();
+        Map<String, ParameterDescription> fieldToParameterDescription = jCommander.getParameters()
+                .stream().collect(Collectors.toMap(
+                        parameterDescription -> parameterDescription.getParameterized().getName(),
+                        parameterDescription -> parameterDescription ));
+        for (String field : runtimeRequiredFields) {
+            ParameterDescription parameterDescription = fieldToParameterDescription.get(field);
+            if (valueIsMissing(parameterDescription)) {
+                missingFields.add("[" + String.join(" | ", parameterDescription.getParameter().names()) + "]");
+            }
+        }
+        if (!missingFields.isEmpty()) {
+            String message = String.join(", ", missingFields);
+            throw new ParameterException("The following "
+                    + (missingFields.size() == 1 ? "option is required: " : "options are required: ")
+                    + message);
+        }
+    }
+
+    private List<String> computeRequiredFields(CommandLineArguments arguments) {
+        List<String> computedRequiredFields = new ArrayList<>(Arrays.asList(requiredFields));
+        if (!arguments.isSingleSignOn()) {
+            computedRequiredFields.add("user");
+        }
+        return computedRequiredFields;
+    }
+
+    private boolean valueIsMissing(ParameterDescription parameterDescription) {
+        Object value = parameterDescription.getParameterized().get(parameterDescription.getObject());
+        if (value instanceof String) {
+            return ((String)value).isEmpty();
+        }
+        return Objects.isNull(value);
+    }
+
 
     /**
      * Prints documentation about the usage of command line arguments to the console.
@@ -63,7 +110,7 @@ public class CommandLineArgumentParser {
         builder.append(System.lineSeparator());
         builder.append(System.lineSeparator());
 
-        LOGGER.info(builder.toString());
+        LOGGER.info("{}", builder);
     }
 
     /**

--- a/src/main/java/org/schemaspy/cli/CommandLineArguments.java
+++ b/src/main/java/org/schemaspy/cli/CommandLineArguments.java
@@ -74,10 +74,18 @@ public class CommandLineArguments {
 
     @Parameter(
             names = {
+                    "-sso","--single-sign-on",
+                    "schemaspy.sso", "schemaspy.single-sign-on"
+            },
+            descriptionKey = "sso"
+    )
+    private boolean sso = false;
+
+    @Parameter(
+            names = {
                     "-u", "--user", "user",
                     "schemaspy.u", "schemaspy.user"},
-            descriptionKey = "user",
-            required = true
+            descriptionKey = "user"
     )
     private String user;
 
@@ -100,16 +108,16 @@ public class CommandLineArguments {
     )
     private String catalog;
 
-    // TODO Password handling is more complex, see Config class (prompt for password, fallback to Environment variable, multiple schemas, etc.)
-//    @Parameter(
-//            names = {
-//                    "-p", "--password", "password",
-//                    "schemaspy.p", "schemaspy.password"
-//            },
-//            descriptionKey = "password",
-//            password = true
-//    )
-//    private String password;
+    /* TODO Password handling is more complex, see Config class (prompt for password, fallback to Environment variable, multiple schemas, etc.)
+    @Parameter(
+            names = {
+                    "-p", "--password", "password",
+                    "schemaspy.p", "schemaspy.password"
+            },
+            descriptionKey = "password",
+            password = true
+    )
+    private String password; */
 
     @Parameter(
             names = {
@@ -125,8 +133,7 @@ public class CommandLineArguments {
                     "-o", "--outputDirectory", "outputDirectory",
                     "schemaspy.o", "schemaspy.outputDirectory"
             },
-            descriptionKey = "outputDirectory",
-            required = true
+            descriptionKey = "outputDirectory"
     )
     private File outputDirectory;
 
@@ -160,6 +167,10 @@ public class CommandLineArguments {
 
     public String getSchema() {
         return schema;
+    }
+
+    public boolean isSingleSignOn() {
+        return sso;
     }
 
     public String getUser() {

--- a/src/main/java/org/schemaspy/cli/PropertyFileDefaultProvider.java
+++ b/src/main/java/org/schemaspy/cli/PropertyFileDefaultProvider.java
@@ -7,6 +7,8 @@ import org.springframework.util.FileCopyUtils;
 
 import java.io.*;
 import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 
@@ -22,6 +24,8 @@ public class PropertyFileDefaultProvider implements IDefaultProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final Properties properties;
+
+    private final List<String> booleans = Arrays.asList("schemaspy.sso","schemaspy.debug");
 
     public PropertyFileDefaultProvider(String propertiesFilename) {
         Objects.requireNonNull(propertiesFilename);
@@ -44,6 +48,10 @@ public class PropertyFileDefaultProvider implements IDefaultProvider {
 
     @Override
     public String getDefaultValueFor(String optionName) {
+        if (booleans.contains(optionName)) {
+            String value = properties.getProperty(optionName, Boolean.FALSE.toString());
+            return value.isEmpty() ? Boolean.TRUE.toString() : value;
+        }
         return properties.getProperty(optionName);
     }
 }

--- a/src/main/resources/commandlinearguments.properties
+++ b/src/main/resources/commandlinearguments.properties
@@ -10,3 +10,4 @@ outputDirectory=directory to place the generated output in
 dbhelp=Show built-in database types and their required connection parameters
 databaseName=Name of database to connect to
 debug=Enable debug logging
+sso=Remove requirement for user

--- a/src/test/java/org/schemaspy/cli/CommandLineArgumentParserTest.java
+++ b/src/test/java/org/schemaspy/cli/CommandLineArgumentParserTest.java
@@ -1,10 +1,10 @@
 package org.schemaspy.cli;
 
 import com.beust.jcommander.ParameterException;
+import org.junit.Rule;
 import org.junit.Test;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
+import org.schemaspy.testing.Logger;
+import org.schemaspy.testing.LoggingRule;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -15,6 +15,9 @@ import static org.mockito.Mockito.mock;
 public class CommandLineArgumentParserTest {
 
     private static final PropertyFileDefaultProvider NO_DEFAULT_PROVIDER = null;
+
+    @Rule
+    public LoggingRule loggingRule = new LoggingRule();
 
     @Test
     public void givenNoRequiredParameterProvided_AndNoDefaultProvider_ExpectError() {
@@ -42,16 +45,15 @@ public class CommandLineArgumentParserTest {
      */
     @Test
     public void givenAllRequiredParamsProvided_ExpectToSuccessfullyParseCommandLineArguments() throws Exception {
-        Path myOutputDirecotry = Files.createTempDirectory("myOutputDirecotry");
-
         String[] args = {
-                "-o", myOutputDirecotry.toString(),
-                "-u", "MyUser"};
+                "-o", "aFolder",
+                "-u", "MyUser"
+        };
         CommandLineArgumentParser parser = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER);
 
         CommandLineArguments arguments = parser.parse(args);
 
-        assertThat(arguments.getOutputDirectory()).isEqualTo(myOutputDirecotry.toFile());
+        assertThat(arguments.getOutputDirectory().getPath()).isEqualTo("aFolder");
         assertThat(arguments.getUser()).isEqualTo("MyUser");
     }
 
@@ -67,6 +69,48 @@ public class CommandLineArgumentParserTest {
 
         assertThat(commandLineArguments.getOutputDirectory()).isNotNull();
         assertThat(commandLineArguments.getUser()).isNotNull();
+    }
+
+    @Test
+    public void ssoIsEnabledOnCommandLineUserIsNotRequired() {
+        String[] args = {
+                "-o", "aFolder",
+                "-sso"
+        };
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER);
+
+        CommandLineArguments arguments = parser.parse(args);
+
+        assertThat(arguments.getOutputDirectory().getPath()).isEqualTo("aFolder");
+        assertThat(arguments.getUser()).isNull();
+    }
+
+    @Test
+    public void ssoIsEnabledInPropertiesFileUserIsNotRequired() {
+        PropertyFileDefaultProvider defaultProvider = mock(PropertyFileDefaultProvider.class);
+        given(defaultProvider.getDefaultValueFor("schemaspy.outputDirectory")).willReturn("mydirectory");
+        given(defaultProvider.getDefaultValueFor("schemaspy.sso")).willReturn(Boolean.TRUE.toString());
+
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(defaultProvider);
+
+        CommandLineArguments commandLineArguments = parser.parse();
+
+        assertThat(commandLineArguments.getOutputDirectory()).isNotNull();
+        assertThat(commandLineArguments.getUser()).isNull();
+    }
+
+    @Test
+    @Logger(CommandLineArgumentParser.class)
+    public void printUsage() {
+        String[] args = {
+                "-o", "aFolder",
+                "-sso"
+        };
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER);
+
+        CommandLineArguments arguments = parser.parse(args);
+        parser.printUsage();
+        assertThat(loggingRule.getLog()).contains("Options:");
     }
 
     //TODO Implement integration tests (?) for following scenarios, addressing the behavior of ApplicationStartListener.

--- a/src/test/java/org/schemaspy/cli/PropertyFileDefaultProviderTest.java
+++ b/src/test/java/org/schemaspy/cli/PropertyFileDefaultProviderTest.java
@@ -1,0 +1,50 @@
+package org.schemaspy.cli;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertyFileDefaultProviderTest {
+
+    @ClassRule
+    public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static PropertyFileDefaultProvider propertyFileDefaultProvider;
+
+    @BeforeClass
+    public static void createPropertiesFile() throws IOException {
+        File propertiesFile = temporaryFolder.newFile("schemaspy.properties");
+        try (BufferedWriter bufferedWriter = Files.newBufferedWriter(propertiesFile.toPath(), StandardCharsets.UTF_8)) {
+            bufferedWriter.write("schemaspy.user=humbug");
+            bufferedWriter.newLine();
+            bufferedWriter.write("schemaspy.sso");
+            bufferedWriter.newLine();
+            bufferedWriter.write("schemaspy.debug=false");
+        }
+        propertyFileDefaultProvider = new PropertyFileDefaultProvider(propertiesFile.getAbsolutePath());
+    }
+
+    @Test
+    public void getStringValue() {
+        assertThat(propertyFileDefaultProvider.getDefaultValueFor("schemaspy.user")).isEqualTo("humbug");
+    }
+
+    @Test
+    public void getSSOWithOutValueShouldBeTrue() {
+        assertThat(propertyFileDefaultProvider.getDefaultValueFor("schemaspy.sso")).isEqualTo(Boolean.TRUE.toString());
+    }
+
+    @Test
+    public void getDebugWithValueFalseShouldBeFalse() {
+        assertThat(propertyFileDefaultProvider.getDefaultValueFor("schemaspy.debug")).isEqualTo(Boolean.FALSE.toString());
+    }
+}


### PR DESCRIPTION
* Moved all validation outside of jCommander (one place)
  CommandLineArgumentParser
* Enabled boolean handling of propertiesFile schemaspy.properties
  `schemaspy.sso` and `schemaspy.debug`
* Added test for boolean handling
* Removed file-system dependency in CommandLineArgumentParserTest

* fixes #243