### PR TITLE
Only log stacktraces when -debug or --debug

### DIFF
--- a/src/main/java/org/schemaspy/Config.java
+++ b/src/main/java/org/schemaspy/Config.java
@@ -929,7 +929,9 @@ public final class Config {
             try {
                 tableInclusions = Pattern.compile(strInclusions);
             } catch (PatternSyntaxException badPattern) {
-                throw new InvalidConfigurationException(badPattern).setParamName("-i");
+                throw new InvalidConfigurationException(badPattern)
+                        .setParamName("-i")
+                        .setParamValue(strInclusions);
             }
         }
 
@@ -961,7 +963,9 @@ public final class Config {
             try {
                 tableExclusions = Pattern.compile(strExclusions);
             } catch (PatternSyntaxException badPattern) {
-                throw new InvalidConfigurationException(badPattern).setParamName("-I");
+                throw new InvalidConfigurationException(badPattern)
+                        .setParamName("-I")
+                        .setParamValue(strExclusions);
             }
         }
 
@@ -1040,7 +1044,7 @@ public final class Config {
                 sqlFormatter = clazz.newInstance();
             } catch (Exception exc) {
                 throw new InvalidConfigurationException("Failed to initialize instance of SQL formatter: ", exc)
-                        .setParamName("-sqlFormatter");
+                        .setParamName("-sqlFormatter").setParamValue(sqlFormatterClass);
             }
         }
 

--- a/src/main/java/org/schemaspy/Main.java
+++ b/src/main/java/org/schemaspy/Main.java
@@ -18,8 +18,10 @@
  */
 package org.schemaspy;
 
+import ch.qos.logback.classic.PatternLayout;
 import org.schemaspy.cli.CommandLineArgumentParser;
 import org.schemaspy.cli.CommandLineArguments;
+import org.schemaspy.logging.LogLevelConditionalThrowableProxyConverter;
 import org.schemaspy.model.ConnectionFailure;
 import org.schemaspy.model.EmptySchemaException;
 import org.schemaspy.model.InvalidConfigurationException;
@@ -53,6 +55,7 @@ public class Main implements CommandLineRunner {
     private ApplicationContext context;
 
     public static void main(String... args) throws Exception {
+        LogLevelConditionalThrowableProxyConverter.register();
         SpringApplication.run(Main.class, args);
     }
 

--- a/src/main/java/org/schemaspy/Main.java
+++ b/src/main/java/org/schemaspy/Main.java
@@ -18,7 +18,6 @@
  */
 package org.schemaspy;
 
-import ch.qos.logback.classic.PatternLayout;
 import org.schemaspy.cli.CommandLineArgumentParser;
 import org.schemaspy.cli.CommandLineArguments;
 import org.schemaspy.logging.LogLevelConditionalThrowableProxyConverter;
@@ -88,15 +87,12 @@ public class Main implements CommandLineRunner {
             LOGGER.warn("Empty schema", noData);
             rc = 2;
         } catch (InvalidConfigurationException badConfig) {
-            LOGGER.info("");
-            if (badConfig.getParamName() != null)
-                LOGGER.warn("Bad parameter specified for {}", badConfig.getParamName());
-            LOGGER.warn("Bad config {}", badConfig.getMessage());
-            if (badConfig.getCause() != null && !badConfig.getMessage().endsWith(badConfig.getMessage()))
-                LOGGER.warn(" caused by {}", badConfig.getCause().getMessage());
-
             LOGGER.debug("Command line parameters: {}", Arrays.asList(args));
-            LOGGER.debug("Invalid configuration detected", badConfig);
+            if (badConfig.getParamName() != null) {
+                LOGGER.error("Bad parameter '{} {}' , {}", badConfig.getParamName(), badConfig.getParamValue(), badConfig.getMessage(), badConfig);
+            } else {
+                LOGGER.error("Bad config {}", badConfig.getMessage(), badConfig);
+            }
         } catch (ProcessExecutionException badLaunch) {
             LOGGER.warn(badLaunch.getMessage(), badLaunch);
         } catch (Exception exc) {

--- a/src/main/java/org/schemaspy/db/config/PropertiesResolver.java
+++ b/src/main/java/org/schemaspy/db/config/PropertiesResolver.java
@@ -46,7 +46,9 @@ public class PropertiesResolver {
             LOGGER.info(resolutionInfo.getTrace());
             return props;
         } catch (ResourceNotFoundException rnfe) {
-            throw new InvalidConfigurationException("Unable to resolve databaseType: " + dbType, rnfe).setParamName("-t");
+            throw new InvalidConfigurationException("Unable to resolve databaseType: " + dbType, rnfe)
+                    .setParamName("-t")
+                    .setParamValue(dbType);
         }
     }
 

--- a/src/main/java/org/schemaspy/logging/LogLevelConditionalThrowableProxyConverter.java
+++ b/src/main/java/org/schemaspy/logging/LogLevelConditionalThrowableProxyConverter.java
@@ -1,0 +1,24 @@
+package org.schemaspy.logging;
+
+import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.CoreConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LogLevelConditionalThrowableProxyConverter extends ThrowableProxyConverter {
+
+    private static final Logger SCHEMA_SPY_LOGGER = LoggerFactory.getLogger("org.schemaspy");
+
+    public static void register() {
+        PatternLayout.defaultConverterMap.put("debugEx", LogLevelConditionalThrowableProxyConverter.class.getName());
+    }
+
+    @Override
+    public String convert(ILoggingEvent event) {
+        if (SCHEMA_SPY_LOGGER.isDebugEnabled())
+            return super.convert(event);
+        return CoreConstants.EMPTY_STRING;
+    }
+}

--- a/src/main/java/org/schemaspy/model/InvalidConfigurationException.java
+++ b/src/main/java/org/schemaspy/model/InvalidConfigurationException.java
@@ -18,6 +18,8 @@
  */
 package org.schemaspy.model;
 
+import java.util.Objects;
+
 /**
  * Base class to indicate that there was problem with how SchemaSpy was configured / used.
  *
@@ -26,6 +28,7 @@ package org.schemaspy.model;
 public class InvalidConfigurationException extends RuntimeException {
     private static final long serialVersionUID = 1L;
     private String paramName;
+    private String paramValue = "";
 
     /**
      * When a message is sufficient
@@ -63,5 +66,15 @@ public class InvalidConfigurationException extends RuntimeException {
 
     public String getParamName() {
         return paramName;
+    }
+
+    public InvalidConfigurationException setParamValue(String paramValue) {
+        if (Objects.nonNull(paramValue))
+            this.paramValue = paramValue;
+        return this;
+    }
+
+    public String getParamValue() {
+        return paramValue;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+spring.profiles.active=default
 # In production mode we deactivate all logging below WARN-Level
 # because SchemaSpy is a command line application.
 # We do not want to bother the user with verbose output like initializing the Spring context.
@@ -16,4 +17,4 @@ logging.level.root=WARN
 # - errors on missing files or exceptions
 logging.level.org.schemaspy=INFO
 
-logging.pattern.console=%clr(%-5level) - %msg%n
+logging.pattern.console=%clr(%-5level) - %msg%n%debugEx


### PR DESCRIPTION
I read a comment that we might not want to print stacktraces in the faces of our users.
So just for fun I added a logback ThrowableConverter that only prints stacktrace if org.schemaspy logger is in level debug (which it is either by -debug or --debug)
Also altered some logging to make a good use-case.

So with no debug:
![image](https://user-images.githubusercontent.com/4175123/36068207-04d1d96e-0ed0-11e8-8a8a-0e30f92f6c05.png)

And with -debug:
![image](https://user-images.githubusercontent.com/4175123/36068213-3bacb74c-0ed0-11e8-8d65-69eceee05fa5.png)

The rational would be that we could add stacktraces to all logging and just have them skipped in normal flow and have them added in debug.

This would be to avoid
```
LOGGER.warn("Something went wrong");
LOGGER.debug("this is why", exception);
```