### PR TITLE
Validation is skipped if help parameter is assigned

### DIFF
--- a/src/main/java/org/schemaspy/cli/CommandLineArgumentParser.java
+++ b/src/main/java/org/schemaspy/cli/CommandLineArgumentParser.java
@@ -46,8 +46,23 @@ public class CommandLineArgumentParser {
 
         jCommander.parse(localArgs);
 
-        validate(arguments);
+        if (shouldValidate()) {
+            validate(arguments);
+        }
         return arguments;
+    }
+
+    private boolean shouldValidate() {
+        List<ParameterDescription> helpParameters = jCommander.getParameters()
+                .stream()
+                .filter(ParameterDescription::isHelp)
+                .collect(Collectors.toList());
+        for(ParameterDescription parameterDescription: helpParameters) {
+            if (parameterDescription.isAssigned()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void validate(CommandLineArguments arguments) {

--- a/src/test/java/org/schemaspy/cli/CommandLineArgumentParserTest.java
+++ b/src/test/java/org/schemaspy/cli/CommandLineArgumentParserTest.java
@@ -113,6 +113,26 @@ public class CommandLineArgumentParserTest {
         assertThat(loggingRule.getLog()).contains("Options:");
     }
 
+    @Test
+    public void onlyHelpSetsHelpRequiredShowsHelp() {
+        String[] args = {
+                "-help"
+        };
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER);
+        CommandLineArguments arguments = parser.parse(args);
+        assertThat(arguments.isHelpRequired()).isTrue();
+    }
+
+    @Test
+    public void onlyDBHelpSetsDBHelpRequired() {
+        String[] args = {
+                "-dbHelp"
+        };
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER);
+        CommandLineArguments arguments = parser.parse(args);
+        assertThat(arguments.isDbHelpRequired()).isTrue();
+    }
+
     //TODO Implement integration tests (?) for following scenarios, addressing the behavior of ApplicationStartListener.
 
     // given only parameter -configFile without value -> error


### PR DESCRIPTION
During my last change I forgot that -help and -dbhelp should skip the validation.