### PR TITLE
Fix mysql row count

### DIFF
--- a/src/main/resources/org/schemaspy/types/mysql.properties
+++ b/src/main/resources/org/schemaspy/types/mysql.properties
@@ -34,7 +34,7 @@ selectViewsSql=select table_schema as view_catalog, null as view_schema, table_n
 # this should be significantly faster than the default implementation, but will be
 #  a rough estimate for InnoDB-based tables  
 # this is only used for remote tables since row_count was returned in selectTablesSql
-selectRowCountSql=select table_rows row_count from information_schema.tables where table_name=:table 
+selectRowCountSql=select table_rows row_count from information_schema.tables where table_name=:table and table_schema=:schema
 
 # return table_name, column_name, column_type, short_column_type for a specific :schema
 # for all column types that have special formatting.


### PR DESCRIPTION
If multiple databases have a table of the same name, the row count computed may be for the wrong database.