### PR TITLE
SchemaMeta comment updates db.getSchema().setComment(String)

### DIFF
--- a/src/main/java/org/schemaspy/model/xml/SchemaMeta.java
+++ b/src/main/java/org/schemaspy/model/xml/SchemaMeta.java
@@ -82,7 +82,7 @@ public class SchemaMeta {
         Document doc = parse(metaFile);
 
         NodeList commentsNodes = doc.getElementsByTagName("comments");
-        if (commentsNodes != null && commentsNodes.getLength() > 0)
+        if (commentsNodes != null && commentsNodes.getLength() > 0 && commentsNodes.item(0).hasChildNodes())
             comments = commentsNodes.item(0).getTextContent();
         else
             comments = null;

--- a/src/main/java/org/schemaspy/service/DatabaseService.java
+++ b/src/main/java/org/schemaspy/service/DatabaseService.java
@@ -209,7 +209,7 @@ public class DatabaseService {
     private void updateFromXmlMetadata(Config config, Database db, SchemaMeta schemaMeta) throws SQLException {
         if (schemaMeta != null) {
             if (Objects.nonNull(schemaMeta.getComments())) {
-                config.setDescription(schemaMeta.getComments());
+                db.getSchema().setComment(schemaMeta.getComments());
             }
 
             // done in three passes:

--- a/src/test/java/org/schemaspy/integrationtesting/SchemaMetaIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/SchemaMetaIT.java
@@ -1,6 +1,9 @@
 package org.schemaspy.integrationtesting;
 
-import org.junit.*;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -123,8 +126,6 @@ public class SchemaMetaIT {
     }
 
     @Test
-    @Ignore
-    //Reported as issue #199
     public void commentsAreReplacedWithReplaceComments() throws Exception {
         SchemaMeta schemaMeta = new SchemaMeta("src/test/resources/integrationTesting/schemaMetaIT/input/replaceComments.xml","SchemaMetaIT", schema);
         Database database = new Database(null, databaseMetaData, "SchemaMetaIT", catalog, schema, schemaMeta, progressListener);


### PR DESCRIPTION
* Added fix for null comment so that it's ignored.
* Schema.comments can't be cleared only overwritten.
* Setting description is only possible from commandline.

Possible fix for #199 