### PR TITLE
Added nohtml to CommandLineArguments

### DIFF
--- a/src/main/java/org/schemaspy/cli/CommandLineArguments.java
+++ b/src/main/java/org/schemaspy/cli/CommandLineArguments.java
@@ -88,6 +88,15 @@ public class CommandLineArguments {
 
     @Parameter(
             names = {
+                    "-nohtml", "--no-html", "nohtml",
+                    "schemaspy.nohtml"
+            },
+            descriptionKey = "nohtml"
+    )
+    private boolean nohtml = false;
+
+    @Parameter(
+            names = {
                     "-t", "--database-type", "database-type",
                     "schemaspy.t", "schemaspy.database-type"
             },
@@ -191,6 +200,14 @@ public class CommandLineArguments {
 
     public boolean isDebug() {
         return debug;
+    }
+
+    public boolean isHtmlDisabled() {
+        return nohtml;
+    }
+
+    public boolean isHtmlEnabled() {
+        return !nohtml;
     }
 
     public String getDatabaseType() {

--- a/src/main/java/org/schemaspy/cli/PropertyFileDefaultProvider.java
+++ b/src/main/java/org/schemaspy/cli/PropertyFileDefaultProvider.java
@@ -48,7 +48,7 @@ public class PropertyFileDefaultProvider implements IDefaultProvider {
 
     private final Properties properties;
 
-    private final List<String> booleans = Arrays.asList("schemaspy.sso","schemaspy.debug");
+    private final List<String> booleans = Arrays.asList("schemaspy.sso","schemaspy.debug","schemaspy.nohtml");
 
     public PropertyFileDefaultProvider(String propertiesFilename) {
         Objects.requireNonNull(propertiesFilename);

--- a/src/main/resources/commandlinearguments.properties
+++ b/src/main/resources/commandlinearguments.properties
@@ -12,3 +12,4 @@ databaseName=Name of database to connect to
 debug=Enable debug logging
 sso=Remove requirement for user
 license=Print license, it will first print GPL and then LGPL (LGPL is addition to GPL)
+nohtml=Skip html generation

--- a/src/test/java/org/schemaspy/cli/CommandLineArgumentParserTest.java
+++ b/src/test/java/org/schemaspy/cli/CommandLineArgumentParserTest.java
@@ -172,6 +172,31 @@ public class CommandLineArgumentParserTest {
         assertThat(log).contains("GNU LESSER GENERAL PUBLIC LICENSE");
     }
 
+    @Test
+    public void skipHtmlIsFalseByDefault() {
+        String[] args = {
+                "-o", "aFolder",
+                "-sso"
+        };
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(),NO_DEFAULT_PROVIDER);
+        CommandLineArguments arguments = parser.parse(args);
+        assertThat(arguments.isHtmlDisabled()).isFalse();
+        assertThat(arguments.isHtmlEnabled()).isTrue();
+    }
+
+    @Test
+    public void skipHtmlCanBeEnabled() {
+        String[] args = {
+                "-o", "aFolder",
+                "-sso",
+                "-nohtml"
+        };
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(),NO_DEFAULT_PROVIDER);
+        CommandLineArguments arguments = parser.parse(args);
+        assertThat(arguments.isHtmlDisabled()).isTrue();
+        assertThat(arguments.isHtmlEnabled()).isFalse();
+    }
+
     //TODO Implement integration tests (?) for following scenarios, addressing the behavior of ApplicationStartListener.
 
     // given only parameter -configFile without value -> error

--- a/src/test/java/org/schemaspy/cli/PropertyFileDefaultProviderTest.java
+++ b/src/test/java/org/schemaspy/cli/PropertyFileDefaultProviderTest.java
@@ -50,22 +50,33 @@ public class PropertyFileDefaultProviderTest {
             bufferedWriter.write("schemaspy.sso");
             bufferedWriter.newLine();
             bufferedWriter.write("schemaspy.debug=false");
+            bufferedWriter.newLine();
+            bufferedWriter.write("schemaspy.nohtml");
         }
         propertyFileDefaultProvider = new PropertyFileDefaultProvider(propertiesFile.getAbsolutePath());
     }
 
     @Test
     public void getStringValue() {
-        assertThat(propertyFileDefaultProvider.getDefaultValueFor("schemaspy.user")).isEqualTo("humbug");
+        assertThat(getDefaultValueFor("schemaspy.user")).isEqualTo("humbug");
     }
 
     @Test
     public void getSSOWithOutValueShouldBeTrue() {
-        assertThat(propertyFileDefaultProvider.getDefaultValueFor("schemaspy.sso")).isEqualTo(Boolean.TRUE.toString());
+        assertThat(getDefaultValueFor("schemaspy.sso")).isEqualTo(Boolean.TRUE.toString());
     }
 
     @Test
     public void getDebugWithValueFalseShouldBeFalse() {
-        assertThat(propertyFileDefaultProvider.getDefaultValueFor("schemaspy.debug")).isEqualTo(Boolean.FALSE.toString());
+        assertThat(getDefaultValueFor("schemaspy.debug")).isEqualTo(Boolean.FALSE.toString());
+    }
+
+    @Test
+    public void getNoHTMLWithoutValue() {
+        assertThat(getDefaultValueFor("schemaspy.nohtml")).isEqualTo(Boolean.TRUE.toString());
+    }
+
+    private String getDefaultValueFor(String optionName) {
+        return propertyFileDefaultProvider.getDefaultValueFor(optionName);
     }
 }


### PR DESCRIPTION
* nohtml is not an output attribute but an application/processing

End goal is to move progresslistener from the creation in SchemaAnalyzer to a bean, so it can be injected in multiple places and not passed as argument.

Later on this will help when switching from current progresslistener to an implementation with commandline progressbar.