### PR TITLE
Moved hardcoded exclusion of tables with $ to default exclusion.

### DIFF
--- a/src/main/java/org/schemaspy/Config.java
+++ b/src/main/java/org/schemaspy/Config.java
@@ -40,7 +40,6 @@ import java.io.*;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.DatabaseMetaData;
@@ -123,7 +122,7 @@ public final class Config {
     public static final String DOT_CHARSET = "UTF-8";
     private static final String ESCAPED_EQUALS = "\\=";
     private static final String DEFAULT_TABLE_INCLUSION = ".*"; // match everything
-    private static final String DEFAULT_TABLE_EXCLUSION = "";   // match nothing
+    private static final String DEFAULT_TABLE_EXCLUSION = ".*\\$.*";
     private static final String DEFAULT_COLUMN_EXCLUSION = "[^.]";  // match nothing
     private static final String DEFAULT_PROPERTIES_FILE = "schemaspy.properties";
     private Properties schemaspyProperties = new Properties();

--- a/src/main/java/org/schemaspy/validator/NameValidator.java
+++ b/src/main/java/org/schemaspy/validator/NameValidator.java
@@ -6,8 +6,6 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 import java.util.HashSet;
 import java.util.Set;
-
-
 import java.util.regex.Pattern;
 
 /**
@@ -50,13 +48,6 @@ public class NameValidator {
         // some databases (MySQL) return more than we wanted
         if (!validTypes.contains(type.toUpperCase()))
             return false;
-
-        // Oracle 10g introduced problematic flashback tables
-        // with bizarre illegal names
-        if (name.contains("$")) {
-            LOGGER.debug("Excluding {} {}: embedded $ implies illegal name", clazz, name);
-            return false;
-        }
 
         if (exclude.matcher(name).matches()) {
             LOGGER.debug("Excluding {} {}: matches exclusion pattern \"{}" + '"', clazz, name, exclude);

--- a/src/test/java/org/schemaspy/validator/NameValidatorIT.java
+++ b/src/test/java/org/schemaspy/validator/NameValidatorIT.java
@@ -1,0 +1,25 @@
+package org.schemaspy.validator;
+
+import org.junit.Test;
+import org.schemaspy.Config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NameValidatorIT {
+
+    @Test
+    public void defaultExcludesDollarSign() {
+        Config config = new Config();
+        NameValidator nameValidator = new NameValidator("table", config.getTableInclusions(), config.getTableExclusions(), new String[]{"TABLE"});
+        boolean valid = nameValidator.isValid("abc$123", "TABLE");
+        assertThat(valid).isFalse();
+    }
+
+    @Test
+    public void overrideDefaultIncludesDollarSign() {
+        Config config = new Config("-I", "");
+        NameValidator nameValidator = new NameValidator("table", config.getTableInclusions(), config.getTableExclusions(), new String[]{"TABLE"});
+        boolean valid = nameValidator.isValid("abc$123", "TABLE");
+        assertThat(valid).isTrue();
+    }
+}

--- a/src/test/java/org/schemaspy/validator/NameValidatorTest.java
+++ b/src/test/java/org/schemaspy/validator/NameValidatorTest.java
@@ -38,9 +38,4 @@ public class NameValidatorTest {
     public void typeDoesntMatch() {
         assertThat(nameValidator.isValid("tablename","view")).isFalse();
     }
-
-    @Test
-    public void excludeTablesWithDollarSigns() {
-        assertThat(nameValidator.isValid("table$name","table")).isFalse();
-    }
 }


### PR DESCRIPTION
* The $ exclusion can now be overriden with `-I ""`

Solves #260 but retains current default.

So without the -I "" it will ignore tables with $ in table name. 
If they have used -I it will include them since it will overwrite default exclude which is .*\\$.* meaning any table name with $ in it.