### PR TITLE
Added -noexportedkeys option to avoid lengthy calls to getExportedKeys()

### DIFF
--- a/src/main/java/org/schemaspy/Config.java
+++ b/src/main/java/org/schemaspy/Config.java
@@ -91,6 +91,7 @@ public final class Config implements HtmlConfig, GraphvizConfig {
     private String host;
     private Integer port;
     private String meta;
+    private Boolean exportedKeysEnabled;
     private String templateDirectory;
     private Pattern tableInclusions;
     private Pattern tableExclusions;
@@ -250,6 +251,13 @@ public final class Config implements HtmlConfig, GraphvizConfig {
         if (meta == null)
             meta = pullParam("-meta");
         return meta;
+    }
+
+    public boolean isExportedKeysEnabled() {
+        if (Objects.isNull(exportedKeysEnabled)) {
+            exportedKeysEnabled = !options.remove("-noexportedkeys");
+        }
+        return exportedKeysEnabled;
     }
 
     public String getTemplateDirectory() {

--- a/src/main/java/org/schemaspy/WiringConfiguration.java
+++ b/src/main/java/org/schemaspy/WiringConfiguration.java
@@ -26,11 +26,18 @@ import org.schemaspy.service.ViewService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.Clock;
+
 /**
  * @author Nils Petzaell
  */
 @Configuration
 public class WiringConfiguration {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
 
     @Bean
     public SqlService sqlService() {
@@ -48,8 +55,8 @@ public class WiringConfiguration {
     }
 
     @Bean
-    public DatabaseService databaseService(TableService tableService, ViewService viewService, SqlService sqlService) {
-        return new DatabaseService(tableService, viewService, sqlService);
+    public DatabaseService databaseService(Clock clock, TableService tableService, ViewService viewService, SqlService sqlService) {
+        return new DatabaseService(clock, tableService, viewService, sqlService);
     }
 
     @Bean

--- a/src/main/java/org/schemaspy/service/TableService.java
+++ b/src/main/java/org/schemaspy/service/TableService.java
@@ -243,7 +243,7 @@ public class TableService {
         // also try to find all of the 'remote' tables in other schemas that
         // point to our primary keys (not necessary in the normal case
         // as we infer this from the opposite direction)
-        if (table.getSchema() != null || table.getCatalog() != null) {
+        if ((table.getSchema() != null || table.getCatalog() != null) && Config.getInstance().isExportedKeysEnabled() ) {
             try (ResultSet rs = sqlService.getDatabaseMetaData().getExportedKeys(table.getCatalog(), table.getSchema(), table.getName())) {
                 // get the foreign keys that reference our primary keys
                 // note that this can take an insane amount of time on Oracle (i.e. 30 secs per call)

--- a/src/main/java/org/schemaspy/util/DurationFormatter.java
+++ b/src/main/java/org/schemaspy/util/DurationFormatter.java
@@ -1,0 +1,29 @@
+package org.schemaspy.util;
+
+public class DurationFormatter {
+
+    private static final long MS_TO_SEC = 1000;
+    private static final long MS_TO_MIN = MS_TO_SEC * 60;
+    private static final long MS_TO_HR = MS_TO_MIN * 60;
+
+    public static String formatMS(final long durationInMilliseconds) {
+        long timeToProcess = durationInMilliseconds;
+        StringBuilder stringBuilder = new StringBuilder();
+        if (timeToProcess >= MS_TO_HR) {
+            stringBuilder.append(timeToProcess/MS_TO_HR).append( " hr ");
+            timeToProcess = timeToProcess % MS_TO_HR;
+        }
+        if (timeToProcess >= MS_TO_MIN) {
+            stringBuilder.append(timeToProcess/MS_TO_MIN).append(" min ");
+            timeToProcess = timeToProcess % MS_TO_MIN;
+        }
+        if (timeToProcess >= MS_TO_SEC) {
+            stringBuilder.append(timeToProcess/MS_TO_SEC).append(" s ");
+            timeToProcess = timeToProcess % MS_TO_SEC;
+        }
+        if (timeToProcess >  0) {
+            stringBuilder.append(timeToProcess).append(" ms");
+        }
+        return stringBuilder.toString().trim();
+    }
+}

--- a/src/test/java/org/schemaspy/ConfigTest.java
+++ b/src/test/java/org/schemaspy/ConfigTest.java
@@ -117,4 +117,16 @@ public class ConfigTest {
         assertThat(dbProps).containsAllEntriesOf(expected);
     }
 
+    @Test
+    public void exportedKeysIsEnabledByDefault() {
+        Config config = new Config();
+        assertThat(config.isExportedKeysEnabled()).isTrue();
+    }
+
+    @Test
+    public void exportedKeysCanBeDisabled() {
+        Config config = new Config("-noexportedkeys");
+        assertThat(config.isExportedKeysEnabled()).isFalse();
+    }
+
 }

--- a/src/test/java/org/schemaspy/service/DatabaseServiceTest.java
+++ b/src/test/java/org/schemaspy/service/DatabaseServiceTest.java
@@ -1,0 +1,126 @@
+package org.schemaspy.service;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.schemaspy.Config;
+import org.schemaspy.model.Database;
+import org.schemaspy.model.ProgressListener;
+import org.schemaspy.model.Table;
+import org.schemaspy.testing.Logger;
+import org.schemaspy.testing.LoggingRule;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.SQLException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.*;
+
+public class DatabaseServiceTest {
+
+    private static final ProgressListener progressListener = mock(ProgressListener.class);
+
+    @Rule
+    public LoggingRule loggingRule = new LoggingRule();
+
+    private Instant currentTime = Instant.now();
+    private Clock clock = mock(Clock.class);
+
+    @Before
+    public void setup() {
+        when(clock.instant()).thenAnswer(invocation -> currentTime);
+    }
+
+    @Test
+    @Logger(DatabaseService.class)
+    public void databaseServicePrintsInformationWhenConnectionTablesWillTakeMoreThan30MinutesAndExportedKeysIsEnabled() throws SQLException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Config config = new Config("-something","thisThing");
+        TableService tableService = mock(TableService.class);
+        doAnswer(invocation -> {
+            currentTime = currentTime.plus(31, ChronoUnit.MINUTES);
+            return null;
+        }).when(tableService).connectForeignKeys(any(),any(),anyMap());
+        ViewService viewService = mock(ViewService.class);
+        SqlService sqlService = mock(SqlService.class);
+        DatabaseService databaseService = new DatabaseService(clock, tableService, viewService, sqlService);
+        List<Table> tablesList = new ArrayList<>();
+        tablesList.add(mock(Table.class));
+        tablesList.add(mock(Table.class));
+        tablesList.add(mock(Table.class));
+        tablesList.add(mock(Table.class));
+        tablesList.add(mock(Table.class));
+        Database database = mock(Database.class);
+        when(database.getTables()).thenReturn(tablesList);
+        Method connectTables = DatabaseService.class.getDeclaredMethod("connectTables", Database.class, ProgressListener.class);
+        connectTables.setAccessible(true);
+
+        connectTables.invoke(databaseService, database, progressListener);
+
+        assertThat(loggingRule.getLog()).contains("Estimated time remaining");
+    }
+
+    @Test
+    @Logger(DatabaseService.class)
+    public void databaseServiceDoesNotPrintInformationWhenConnectionTablesWillTakeMoreThan30MinutesAndExportedKeysIsDisabled() throws SQLException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Config config = new Config("-noexportedkeys");
+        TableService tableService = mock(TableService.class);
+        doAnswer(invocation -> {
+            currentTime = currentTime.plus(31, ChronoUnit.MINUTES);
+            return null;
+        }).when(tableService).connectForeignKeys(any(),any(),anyMap());
+        ViewService viewService = mock(ViewService.class);
+        SqlService sqlService = mock(SqlService.class);
+        DatabaseService databaseService = new DatabaseService(clock, tableService, viewService, sqlService);
+        List<Table> tablesList = new ArrayList<>();
+        tablesList.add(mock(Table.class));
+        tablesList.add(mock(Table.class));
+        tablesList.add(mock(Table.class));
+        tablesList.add(mock(Table.class));
+        tablesList.add(mock(Table.class));
+        Database database = mock(Database.class);
+        when(database.getTables()).thenReturn(tablesList);
+        Method connectTables = DatabaseService.class.getDeclaredMethod("connectTables", Database.class, ProgressListener.class);
+        connectTables.setAccessible(true);
+
+        connectTables.invoke(databaseService, database, progressListener);
+
+        assertThat(loggingRule.getLog()).doesNotContain("Estimated time remaining");
+    }
+
+    @Test
+    @Logger(DatabaseService.class)
+    public void databaseServiceDoesNotPrintInformationWhenConnectionTablesWillTakeLessThan30Minutes() throws SQLException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Config config = new Config("-something","thisThing");
+        TableService tableService = mock(TableService.class);
+        doAnswer(invocation -> {
+            currentTime = currentTime.plus(1, ChronoUnit.MINUTES);
+            return null;
+        }).when(tableService).connectForeignKeys(any(),any(),anyMap());
+        ViewService viewService = mock(ViewService.class);
+        SqlService sqlService = mock(SqlService.class);
+        DatabaseService databaseService = new DatabaseService(clock, tableService, viewService, sqlService);
+        List<Table> tablesList = new ArrayList<>();
+        tablesList.add(mock(Table.class));
+        tablesList.add(mock(Table.class));
+        tablesList.add(mock(Table.class));
+        tablesList.add(mock(Table.class));
+        tablesList.add(mock(Table.class));
+        Database database = mock(Database.class);
+        when(database.getTables()).thenReturn(tablesList);
+        Method connectTables = DatabaseService.class.getDeclaredMethod("connectTables", Database.class, ProgressListener.class);
+        connectTables.setAccessible(true);
+
+        connectTables.invoke(databaseService, database, progressListener);
+
+        assertThat(loggingRule.getLog()).doesNotContain("Estimated time remaining");
+    }
+
+}

--- a/src/test/java/org/schemaspy/util/DurationFormatterTest.java
+++ b/src/test/java/org/schemaspy/util/DurationFormatterTest.java
@@ -1,0 +1,39 @@
+package org.schemaspy.util;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DurationFormatterTest {
+
+    @Test
+    public void lessThenOneSecond() {
+        String formatted = DurationFormatter.formatMS(899);
+        assertThat(formatted).isEqualTo("899 ms");
+    }
+
+    @Test
+    public void lessThenOneMinute() {
+        String formatted = DurationFormatter.formatMS(12345);
+        assertThat(formatted).isEqualTo("12 s 345 ms");
+    }
+
+    @Test
+    public void lessThenOneHour() {
+        String formatted = DurationFormatter.formatMS(123456);
+        assertThat(formatted).isEqualTo("2 min 3 s 456 ms");
+    }
+
+    @Test
+    public void moreThanOneHour() {
+        String formatted = DurationFormatter.formatMS(12345678);
+        assertThat(formatted).isEqualTo("3 hr 25 min 45 s 678 ms");
+    }
+
+    @Test
+    public void exactlyOneMinute() {
+        String formatted = DurationFormatter.formatMS(60000);
+        assertThat(formatted).isEqualTo("1 min");
+    }
+
+}


### PR DESCRIPTION
* Added clock to DatabaseService to test time based code.
* If Estimated time for completion of connectTables.views/tables is
  longer than 30 minutes a logging will appear that the option
  -noexportkeys exists and the implications of using it.

Solves issue #267