### PR TITLE
Removing SchemaMeta from model

### DIFF
--- a/src/main/java/org/schemaspy/SchemaAnalyzer.java
+++ b/src/main/java/org/schemaspy/SchemaAnalyzer.java
@@ -198,8 +198,8 @@ public class SchemaAnalyzer {
             //
             // create our representation of the database
             //
-            Database db = new Database(meta, dbName, catalog, schema, schemaMeta);
-            databaseService.gatheringSchemaDetails(config, db, progressListener);
+            Database db = new Database(meta, dbName, catalog, schema);
+            databaseService.gatheringSchemaDetails(config, db, schemaMeta, progressListener);
 
             long duration = progressListener.startedGraphingSummaries();
 

--- a/src/main/java/org/schemaspy/model/Database.java
+++ b/src/main/java/org/schemaspy/model/Database.java
@@ -18,7 +18,6 @@
  */
 package org.schemaspy.model;
 
-import org.schemaspy.model.xml.SchemaMeta;
 import org.schemaspy.util.CaseInsensitiveMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +25,6 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
-import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -38,14 +36,12 @@ public class Database {
     private final String databaseName ;
     private final Catalog catalog ;
     private final Schema schema;
-    private final Map<String, Table> tables = new CaseInsensitiveMap<Table>();
-    private final Map<String, View> views = new CaseInsensitiveMap<View>();
-    private final Map<String, Table> remoteTables = new CaseInsensitiveMap<Table>(); // key: schema.tableName
+    private final Map<String, Table> tables = new CaseInsensitiveMap<>();
+    private final Map<String, View> views = new CaseInsensitiveMap<>();
+    private final Map<String, Table> remoteTables = new CaseInsensitiveMap<>(); // key: schema.tableName
     private final Map<String, Table> locals = new CombinedMap(tables, views);
-    private final Map<String, Routine> routines = new CaseInsensitiveMap<Routine>();
+    private final Map<String, Routine> routines = new CaseInsensitiveMap<>();
     private final DatabaseMetaData meta;
-    private final SchemaMeta schemaMeta;
-    private final String connectTime = new SimpleDateFormat("EEE MMM dd HH:mm z yyyy").format(new Date());
     private Set<String> sqlKeywords;
     private Pattern invalidIdentifierPattern;
 
@@ -53,11 +49,9 @@ public class Database {
             DatabaseMetaData meta,
             String name,
             String catalog,
-            String schema,
-            SchemaMeta schemaMeta
-    ) throws SQLException, MissingResourceException {
+            String schema
+    ) {
         this.meta = meta;
-        this.schemaMeta = schemaMeta;
         this.databaseName = name;
         this.catalog = new Catalog(catalog);
         this.schema = new Schema(schema);
@@ -128,14 +122,6 @@ public class Database {
 
     public DatabaseMetaData getMetaData() {
         return meta;
-    }
-
-    public SchemaMeta getSchemaMeta() {
-        return schemaMeta;
-    }
-
-    public String getConnectTime() {
-        return connectTime;
     }
 
     public String getDatabaseProduct() {

--- a/src/main/java/org/schemaspy/service/DatabaseService.java
+++ b/src/main/java/org/schemaspy/service/DatabaseService.java
@@ -36,7 +36,7 @@ public class DatabaseService {
         this.sqlService = Objects.requireNonNull(sqlService);
     }
 
-    public void gatheringSchemaDetails(Config config, Database db, ProgressListener listener) throws SQLException {
+    public void gatheringSchemaDetails(Config config, Database db, SchemaMeta schemaMeta, ProgressListener listener) throws SQLException {
         LOGGER.info("Gathering schema details");
 
         listener.startedGatheringDetails();
@@ -63,7 +63,7 @@ public class DatabaseService {
         listener.startedConnectingTables();
 
         connectTables(db, listener);
-        updateFromXmlMetadata(config, db, db.getSchemaMeta());
+        updateFromXmlMetadata(config, db, schemaMeta);
     }
     
    private void initCatalogs(Database db) throws SQLException {

--- a/src/test/java/org/schemaspy/integrationtesting/H2KeywordIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/H2KeywordIT.java
@@ -79,10 +79,9 @@ public class H2KeywordIT {
                 databaseMetaData,
                 arguments.getDatabaseName(),
                 arguments.getCatalog(),
-                arguments.getSchema(),
-                null
+                arguments.getSchema()
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
         this.database = database;
     }
 

--- a/src/test/java/org/schemaspy/integrationtesting/H2SpacesIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/H2SpacesIT.java
@@ -79,10 +79,9 @@ public class H2SpacesIT {
                 databaseMetaData,
                 arguments.getDatabaseName(),
                 arguments.getCatalog(),
-                arguments.getSchema(),
-                null
+                arguments.getSchema()
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
         this.database = database;
     }
 

--- a/src/test/java/org/schemaspy/integrationtesting/H2ViewIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/H2ViewIT.java
@@ -77,10 +77,9 @@ public class H2ViewIT {
                 databaseMetaData,
                 arguments.getDatabaseName(),
                 arguments.getCatalog(),
-                arguments.getSchema(),
-                null
+                arguments.getSchema()
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
         this.database = database;
     }
 

--- a/src/test/java/org/schemaspy/integrationtesting/OracleSpacesIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/OracleSpacesIT.java
@@ -97,10 +97,9 @@ public class OracleSpacesIT {
                 databaseMetaData,
                 arguments.getDatabaseName(),
                 arguments.getCatalog(),
-                arguments.getSchema(),
-                null
+                arguments.getSchema()
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
         this.database = database;
     }
 

--- a/src/test/java/org/schemaspy/integrationtesting/SchemaMetaIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/SchemaMetaIT.java
@@ -94,20 +94,18 @@ public class SchemaMetaIT {
                 databaseMetaData,
                 "DatabaseServiceIT",
                 catalog,
-                schema,
-                null
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
 
         SchemaMeta schemaMeta = new SchemaMeta("src/test/resources/integrationTesting/schemaMetaIT/input/nullTableComment.xml","SchemaMetaIT", schema);
         Database databaseWithSchemaMeta = new Database(
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                schemaMeta
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, progressListener);
+        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, schemaMeta, progressListener);
 
         assertThat(database.getTables().size()).isGreaterThan(0);
         assertThat(database.getSchema().getComment()).isEqualToIgnoringCase(BY_SCRIPT_COMMENT);
@@ -126,20 +124,19 @@ public class SchemaMetaIT {
         Database database = new Database(
                 databaseMetaData,
                 "DatabaseServiceIT",
-                catalog, schema,
-                null
+                catalog,
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
 
         SchemaMeta schemaMeta = new SchemaMeta("src/test/resources/integrationTesting/schemaMetaIT/input/noTableComment.xml","SchemaMetaIT", schema);
         Database databaseWithSchemaMeta = new Database(
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                schemaMeta
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, progressListener);
+        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, schemaMeta, progressListener);
 
         assertThat(database.getTables().size()).isGreaterThan(0);
         assertThat(database.getTablesByName().get("ACCOUNT").getColumn("accountId").getComments()).isNull();
@@ -155,10 +152,9 @@ public class SchemaMetaIT {
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                schemaMeta
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, schemaMeta, progressListener);
 
         assertThat(database.getTables().size()).isGreaterThan(0);
         assertThat(database.getSchema().getComment()).isEqualToIgnoringCase(BY_SCHEMA_META_COMMENT);
@@ -172,20 +168,18 @@ public class SchemaMetaIT {
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                null
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
 
         SchemaMeta schemaMeta = new SchemaMeta("src/test/resources/integrationTesting/schemaMetaIT/input/remoteTable.xml","SchemaMetaIT", schema);
         Database databaseWithSchemaMeta = new Database(
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                schemaMeta
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, progressListener);
+        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, schemaMeta, progressListener);
 
         assertThat(database.getRemoteTables().size()).isLessThan(databaseWithSchemaMeta.getRemoteTables().size());
         assertThat(database.getRemoteTablesMap().get("other.other.CONTRACT")).isNull();
@@ -198,20 +192,18 @@ public class SchemaMetaIT {
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                null
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
 
         SchemaMeta schemaMeta = new SchemaMeta("src/test/resources/integrationTesting/schemaMetaIT/input/remoteTable.xml","SchemaMetaIT", schema);
         Database databaseWithSchemaMeta = new Database(
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                schemaMeta
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, progressListener);
+        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, schemaMeta, progressListener);
 
         assertThat(database.getTablesByName().get("ACCOUNT").getNumChildren())
                 .isLessThan(databaseWithSchemaMeta.getTablesByName().get("ACCOUNT").getNumChildren());
@@ -223,20 +215,18 @@ public class SchemaMetaIT {
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                null
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
 
         SchemaMeta schemaMeta = new SchemaMeta("src/test/resources/integrationTesting/schemaMetaIT/input/addColumn.xml","SchemaMetaIT", schema);
         Database databaseWithSchemaMeta = new Database(
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                schemaMeta
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, progressListener);
+        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, schemaMeta, progressListener);
 
         assertThat(database.getTablesByName().get("ACCOUNT").getColumns().size())
                 .isLessThan(databaseWithSchemaMeta.getTablesByName().get("ACCOUNT").getColumns().size());
@@ -248,20 +238,18 @@ public class SchemaMetaIT {
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                null
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
 
         SchemaMeta schemaMeta = new SchemaMeta("src/test/resources/integrationTesting/schemaMetaIT/input/disableImpliedOnAgent.xml","SchemaMetaIT", schema);
         Database databaseWithSchemaMeta = new Database(
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                schemaMeta
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, progressListener);
+        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, schemaMeta, progressListener);
 
         DbAnalyzer.getImpliedConstraints(database.getTables());
         DbAnalyzer.getImpliedConstraints(databaseWithSchemaMeta.getTables());
@@ -276,20 +264,18 @@ public class SchemaMetaIT {
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                null
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
 
         SchemaMeta schemaMeta = new SchemaMeta("src/test/resources/integrationTesting/schemaMetaIT/input/addFKInsteadOfImplied.xml","SchemaMetaIT", schema);
         Database databaseWithSchemaMeta = new Database(
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                schemaMeta
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, progressListener);
+        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, schemaMeta, progressListener);
 
         assertThat(database.getTablesByName().get("ACCOUNT").getNumChildren())
                 .isLessThan(databaseWithSchemaMeta.getTablesByName().get("ACCOUNT").getNumChildren());
@@ -301,20 +287,18 @@ public class SchemaMetaIT {
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                null
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
 
         SchemaMeta schemaMeta = new SchemaMeta("src/test/resources/integrationTesting/schemaMetaIT/input/disableDiagramAssociations.xml","SchemaMetaIT", schema);
         Database databaseWithSchemaMeta = new Database(
                 databaseMetaData,
                 "SchemaMetaIT",
                 catalog,
-                schema,
-                schemaMeta
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, progressListener);
+        databaseService.gatheringSchemaDetails(config, databaseWithSchemaMeta, schemaMeta, progressListener);
 
         File withoutSchemaMetaOutput = temporaryFolder.newFolder("withOutSchemaMeta");
         try (LineWriter lineWriter = new LineWriter(new File(withoutSchemaMetaOutput, "company.dot"),"UTF-8")) {

--- a/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlKeyWordTableIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlKeyWordTableIT.java
@@ -114,10 +114,9 @@ public class MysqlKeyWordTableIT {
                 databaseMetaData,
                 arguments.getDatabaseName(),
                 arguments.getCatalog(),
-                arguments.getSchema(),
-                null
+                arguments.getSchema()
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
         this.database = database;
     }
 

--- a/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlRoutinesIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlRoutinesIT.java
@@ -113,10 +113,9 @@ public class MysqlRoutinesIT {
                 databaseMetaData,
                 arguments.getDatabaseName(),
                 arguments.getCatalog(),
-                arguments.getSchema(),
-                null
+                arguments.getSchema()
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
         this.database = database;
     }
 

--- a/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlSpacesIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlSpacesIT.java
@@ -121,10 +121,9 @@ public class MysqlSpacesIT {
                 databaseMetaData,
                 arguments.getDatabaseName(),
                 arguments.getCatalog(),
-                arguments.getSchema(),
-                null
+                arguments.getSchema()
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
         this.database = database;
     }
 

--- a/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlSpacesNoDotsIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlSpacesNoDotsIT.java
@@ -114,10 +114,9 @@ public class MysqlSpacesNoDotsIT {
                 databaseMetaData,
                 arguments.getDatabaseName(),
                 arguments.getCatalog(),
-                arguments.getSchema(),
-                null
+                arguments.getSchema()
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
         this.database = database;
     }
 

--- a/src/test/java/org/schemaspy/service/DatabaseServiceIT.java
+++ b/src/test/java/org/schemaspy/service/DatabaseServiceIT.java
@@ -70,10 +70,9 @@ public class DatabaseServiceIT {
                 databaseMetaData,
                 "DatabaseServiceIT",
                 catalog,
-                schema,
-                null
+                schema
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
 
         assertThat(database.getTables()).hasSize(1);
     }

--- a/src/test/java/org/schemaspy/testcontainer/InformixIndexIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/InformixIndexIT.java
@@ -95,10 +95,9 @@ public class InformixIndexIT {
                 databaseMetaData,
                 arguments.getDatabaseName(),
                 arguments.getCatalog(),
-                arguments.getSchema(),
-                null
+                arguments.getSchema()
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
         this.database = database;
     }
 

--- a/src/test/java/org/schemaspy/testcontainer/MSSQLServerIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/MSSQLServerIT.java
@@ -91,10 +91,9 @@ public class MSSQLServerIT {
                 databaseMetaData,
                 arguments.getDatabaseName(),
                 arguments.getCatalog(),
-                arguments.getSchema(),
-                null
+                arguments.getSchema()
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
         this.database = database;
     }
 

--- a/src/test/java/org/schemaspy/testcontainer/OracleIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/OracleIT.java
@@ -100,10 +100,9 @@ public class OracleIT {
                 databaseMetaData,
                 arguments.getDatabaseName(),
                 arguments.getCatalog(),
-                arguments.getSchema(),
-                null
+                arguments.getSchema()
         );
-        databaseService.gatheringSchemaDetails(config, database, progressListener);
+        databaseService.gatheringSchemaDetails(config, database, null, progressListener);
         this.database = database;
     }
 


### PR DESCRIPTION
* Since SchemaMeta augments the model it doesn't need to be part of it
* Also it's used in DatabaseService.gatheringSchemaDetails and
  SchemaMeta is created lines above Database and right after creation
  gatheringSchemaDetails is called.

* Removed connectTime
* Removed Exceptions from constructor
* Diamond clean up