### PR TITLE
Update installation.rst with correct graphviz links

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -15,7 +15,7 @@ Graphviz
 ^^^^^^^^
 
 - Windows
-    The easiest way to install Graphviz is to download the msi package from `http://www.graphviz.org/Download_windows.php <http://www.graphviz.org/Download_windows.php>`_
+    The easiest way to install Graphviz is to download the msi package from `http://www.graphviz.org/download/ <http://www.graphviz.org/download/>`_
     
     .. warning::
         Remember to add the folder containing Graphviz's dot.exe application to your system PATH variable, eg.
@@ -25,7 +25,7 @@ Graphviz
             C:\Program Files (x86)\Graphviz2.38\bin        
 
 - Linux, Mac OS
-    Please read carefully the detailed instructions on how to install Graphviz on your os version `http://www.graphviz.org/Download.php <http://www.graphviz.org/Download.php>`_.
+    Please read carefully the detailed instructions on how to install Graphviz on your os version `http://www.graphviz.org/download/ <http://www.graphviz.org/download/>`_.
 
 SchemaSpy
 ----------


### PR DESCRIPTION
The old links were going to a 404 and a redirect page.
I repointed both to Graphviz's main Download page.