### PR TITLE
Fixed version for mysql

### DIFF
--- a/src/test/java/org/schemaspy/testcontainer/MysqlHTMLIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/MysqlHTMLIT.java
@@ -36,7 +36,7 @@ public class MysqlHTMLIT {
 
     @ClassRule
     public static JdbcContainerRule<MySQLContainer> jdbcContainerRule =
-            new JdbcContainerRule<MySQLContainer>(() -> new MySQLContainer<>("mysql:5.7.18"))
+            new JdbcContainerRule<MySQLContainer>(() -> new MySQLContainer<>("mysql:5"))
                     .assumeDockerIsPresent().withAssumptions(assumeDriverIsPresent())
                     .withQueryString("?useSSL=false")
                     .withInitScript("integrationTesting/dbScripts/mysql_html_implied_relationship.sql");

--- a/src/test/java/org/schemaspy/testcontainer/MysqlHTMLIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/MysqlHTMLIT.java
@@ -7,11 +7,13 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.schemaspy.Main;
+import org.schemaspy.testing.IgnoreUsingXPath;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.testcontainers.containers.MySQLContainer;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.builder.Input;
 import org.xmlunit.diff.Diff;
+import org.xmlunit.diff.DifferenceEvaluators;
 
 import java.io.IOException;
 import java.net.URL;
@@ -62,6 +64,7 @@ public class MysqlHTMLIT {
     public void verifyXML() {
         Diff d = DiffBuilder.compare(Input.fromURL(expectedXML))
                 .withTest(Input.fromFile("target/mysqlhtml/test.test.xml"))
+                .withDifferenceEvaluator(DifferenceEvaluators.chain(DifferenceEvaluators.Default, new IgnoreUsingXPath("/database[1]/@type")))
                 .build();
         assertThat(d.getDifferences()).isEmpty();
     }

--- a/src/test/java/org/schemaspy/testcontainer/MysqlKeyWordTableIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/MysqlKeyWordTableIT.java
@@ -53,7 +53,7 @@ public class MysqlKeyWordTableIT {
 
     @ClassRule
     public static JdbcContainerRule<MySQLContainer> jdbcContainerRule =
-            new JdbcContainerRule<>(() -> new MySQLContainer())
+            new JdbcContainerRule<>(() -> new MySQLContainer("mysql:5"))
                     .assumeDockerIsPresent()
                     .withAssumptions(assumeDriverIsPresent())
                     .withInitScript("integrationTesting/dbScripts/mysql_keyword.sql");

--- a/src/test/java/org/schemaspy/testcontainer/MysqlRoutinesIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/MysqlRoutinesIT.java
@@ -51,7 +51,7 @@ public class MysqlRoutinesIT {
 
     @ClassRule
     public static JdbcContainerRule<MySQLContainer> jdbcContainerRule =
-            new JdbcContainerRule<>(() -> new MySQLContainer())
+            new JdbcContainerRule<>(() -> new MySQLContainer("mysql:5"))
                     .assumeDockerIsPresent()
                     .withAssumptions(assumeDriverIsPresent())
                     .withInitScript("integrationTesting/mysqlroutines/dbScripts/routines.sql");

--- a/src/test/java/org/schemaspy/testcontainer/MysqlSpacesIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/MysqlSpacesIT.java
@@ -59,7 +59,7 @@ public class MysqlSpacesIT {
 
     @ClassRule
     public static JdbcContainerRule<MySQLContainer> jdbcContainerRule =
-            new JdbcContainerRule<>(() -> new MySQLContainer())
+            new JdbcContainerRule<>(() -> new MySQLContainer("mysql:5"))
                     .assumeDockerIsPresent()
                     .withAssumptions(assumeDriverIsPresent())
                     .withInitScript("integrationTesting/dbScripts/mysql_spaces.sql")

--- a/src/test/java/org/schemaspy/testcontainer/MysqlSpacesNoDotsIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/MysqlSpacesNoDotsIT.java
@@ -52,7 +52,7 @@ public class MysqlSpacesNoDotsIT {
 
     @ClassRule
     public static JdbcContainerRule<MySQLContainer> jdbcContainerRule =
-            new JdbcContainerRule<>(() -> new MySQLContainer())
+            new JdbcContainerRule<>(() -> new MySQLContainer("mysql:5"))
                     .assumeDockerIsPresent()
                     .withAssumptions(assumeDriverIsPresent())
                     .withInitScript("integrationTesting/dbScripts/mysql_spaces_no_dots.sql")

--- a/src/test/java/org/schemaspy/testcontainer/MysqlXMLIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/MysqlXMLIT.java
@@ -32,7 +32,7 @@ public class MysqlXMLIT {
 
     @ClassRule
     public static JdbcContainerRule<MySQLContainer> jdbcContainerRule =
-            new JdbcContainerRule<MySQLContainer>(() -> new MySQLContainer<>())
+            new JdbcContainerRule<MySQLContainer>(() -> new MySQLContainer<>("mysql:5"))
             .assumeDockerIsPresent().withAssumptions(assumeDriverIsPresent())
             .withQueryString("?useSSL=false")
             .withInitScript("integrationTesting/dbScripts/mysqlxmlit.sql");


### PR DESCRIPTION
Mysql 8 breaks the tests, this might really be a driver issue, but since we probably have been using 5 I'm pinning it to version 5.x.x.

Also fixed an issue in MysqlHTMLIT when it compared XML, it should ignore version of mysql as we do in MysqlXMLIT.