### PR TITLE
Update mssql05.properties to include schema to prevent empty table comments

### DIFF
--- a/src/main/resources/org/schemaspy/types/mssql05.properties
+++ b/src/main/resources/org/schemaspy/types/mssql05.properties
@@ -24,7 +24,7 @@ dbThreads=1
 
 # return table_name, comments for current schema
 # SQL provided by Stefano Santoro
-selectTableCommentsSql=SELECT i_s.TABLE_NAME, CAST(s.value AS VARCHAR(MAX)) AS comments FROM INFORMATION_SCHEMA.Tables i_s INNER JOIN sys.extended_properties s ON s.major_id \= OBJECT_ID(i_s.table_catalog + '.' + i_s.table_schema + '.' + i_s.table_name) WHERE s.class \= 1 AND s.name \= 'MS_Description' AND s.minor_id \= 0
+selectTableCommentsSql=SELECT i_s.TABLE_NAME, CAST(s.value AS VARCHAR(MAX)) AS comments FROM INFORMATION_SCHEMA.Tables i_s INNER JOIN sys.extended_properties s ON s.major_id \= OBJECT_ID(i_s.table_catalog + '.' + i_s.table_schema + '.' + i_s.table_name) WHERE s.class \= 1 AND s.name \= 'MS_Description' AND s.minor_id \= 0 AND i_s.table_schema \= :schema
 
 # reference: http://databases.aspfaq.com/schema-tutorials/schema-how-do-i-show-the-description-property-of-a-column.html
 # return table_name, column_name, comments for a specific :schema

--- a/src/main/resources/org/schemaspy/types/mssql05.properties
+++ b/src/main/resources/org/schemaspy/types/mssql05.properties
@@ -24,7 +24,7 @@ dbThreads=1
 
 # return table_name, comments for current schema
 # SQL provided by Stefano Santoro
-selectTableCommentsSql=SELECT i_s.TABLE_NAME, CAST(s.value AS VARCHAR(MAX)) AS comments FROM INFORMATION_SCHEMA.Tables i_s INNER JOIN sys.extended_properties s ON s.major_id \= OBJECT_ID(i_s.table_catalog + '..' + i_s.table_name) WHERE s.class \= 1 AND s.name \= 'MS_Description' AND s.minor_id \= 0
+selectTableCommentsSql=SELECT i_s.TABLE_NAME, CAST(s.value AS VARCHAR(MAX)) AS comments FROM INFORMATION_SCHEMA.Tables i_s INNER JOIN sys.extended_properties s ON s.major_id \= OBJECT_ID(i_s.table_catalog + '.' + i_s.table_schema + '.' + i_s.table_name) WHERE s.class \= 1 AND s.name \= 'MS_Description' AND s.minor_id \= 0
 
 # reference: http://databases.aspfaq.com/schema-tutorials/schema-how-do-i-show-the-description-property-of-a-column.html
 # return table_name, column_name, comments for a specific :schema

--- a/src/test/java/org/schemaspy/testcontainer/MSSQLServerIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/MSSQLServerIT.java
@@ -105,6 +105,12 @@ public class MSSQLServerIT {
     }
 
     @Test
+    public void databaseShouldBePopulatedWithTableTestWithComment() {
+        Table table = getTable("TestTable");
+        assertThat(table.getComments()).isEqualToIgnoringCase("This is a table description");
+    }
+
+    @Test
     public void databaseShouldBePopulatedWithTableTestAndHaveColumnName() {
         Table table = getTable("TestTable");
         TableColumn column = table.getColumn("Description");

--- a/src/test/java/org/schemaspy/testcontainer/MSSQLServerIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/MSSQLServerIT.java
@@ -121,7 +121,7 @@ public class MSSQLServerIT {
     public void databaseShouldBePopulatedWithTableTestAndHaveColumnNameWithComment() {
         Table table = getTable("TestTable");
         TableColumn column = table.getColumn("Description");
-        assertThat(column.getComments()).isEqualToIgnoringCase("This is column description");
+        assertThat(column.getComments()).isEqualToIgnoringCase("This is a column description");
     }
 
     private Table getTable(String tableName) {

--- a/src/test/resources/integrationTesting/dbScripts/mssql.sql
+++ b/src/test/resources/integrationTesting/dbScripts/mssql.sql
@@ -11,7 +11,14 @@ CREATE TABLE TestTable
 
 EXEC sys.sp_addextendedproperty
     @name=N'MS_Description',
-    @value=N'This is column description' ,
+    @value=N'This is a table description' ,
+    @level0type=N'SCHEMA',@level0name=N'dbo',
+    @level1type=N'TABLE',@level1name=N'TestTable',
+    @level2type=null,@level2name=null
+
+EXEC sys.sp_addextendedproperty
+    @name=N'MS_Description',
+    @value=N'This is a column description' ,
     @level0type=N'SCHEMA',@level0name=N'dbo',
     @level1type=N'TABLE',@level1name=N'TestTable',
     @level2type=N'COLUMN',@level2name=N'Description'


### PR DESCRIPTION
In the default mssql05.properties file, the selectTableCommentsSql query does not include the schema when building the Object ID which causes joins to fail and comments to be skipped for tables. Adding the schema name resolves the issue.