### PR TITLE
Main.run doesn't call System.exit()

### DIFF
--- a/src/main/java/org/schemaspy/Main.java
+++ b/src/main/java/org/schemaspy/Main.java
@@ -123,7 +123,8 @@ public class Main implements CommandLineRunner {
     }
 
     private void exitApplication(int returnCode) {
-        SpringApplication.exit(context, () -> returnCode);
+        int computedReturnCode = SpringApplication.exit(context, () -> returnCode);
+        System.exit(computedReturnCode);
     }
 
 }

--- a/src/main/java/org/schemaspy/Main.java
+++ b/src/main/java/org/schemaspy/Main.java
@@ -25,22 +25,10 @@
  */
 package org.schemaspy;
 
-import org.schemaspy.cli.CommandLineArgumentParser;
-import org.schemaspy.cli.CommandLineArguments;
-import org.schemaspy.model.ConnectionFailure;
-import org.schemaspy.model.EmptySchemaException;
-import org.schemaspy.model.InvalidConfigurationException;
-import org.schemaspy.model.ProcessExecutionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
+import org.schemaspy.cli.SchemaSpyRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.ApplicationContext;
-
-import java.lang.invoke.MethodHandles;
-import java.util.Arrays;
+import org.springframework.context.ConfigurableApplicationContext;
 
 /**
  * @author John Currier
@@ -52,79 +40,14 @@ import java.util.Arrays;
  * @author Nils Petzaell
  */
 @SpringBootApplication
-public class Main implements CommandLineRunner {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-    @Autowired
-    private SchemaAnalyzer analyzer;
-
-    @Autowired
-    private CommandLineArguments arguments;
-
-    @Autowired
-    private CommandLineArgumentParser commandLineArgumentParser;
-
-    @Autowired
-    private ApplicationContext context;
+public class Main {
 
     public static void main(String... args) {
-        SpringApplication.run(Main.class, args);
-    }
-
-    @Override
-    public void run(String... args) {
-        if (arguments.isHelpRequired()) {
-            commandLineArgumentParser.printUsage();
-            exitApplication(0);
-            return;
-        }
-
-        if (arguments.isDbHelpRequired()) {
-            commandLineArgumentParser.printDatabaseTypesHelp();
-            exitApplication(0);
-            return;
-        }
-
-        if (arguments.isPrintLicense()) {
-            commandLineArgumentParser.printLicense();
-            exitApplication(0);
-            return;
-        }
-
-        runAnalyzer(args);
-    }
-
-    private void runAnalyzer(String... args) {
-        int rc = 1;
-
-        try {
-            rc = analyzer.analyze(new Config(args)) == null ? 1 : 0;
-        } catch (ConnectionFailure couldntConnect) {
-            LOGGER.warn("Connection Failure", couldntConnect);
-            rc = 3;
-        } catch (EmptySchemaException noData) {
-            LOGGER.warn("Empty schema", noData);
-            rc = 2;
-        } catch (InvalidConfigurationException badConfig) {
-            LOGGER.debug("Command line parameters: {}", Arrays.asList(args));
-            if (badConfig.getParamName() != null) {
-                LOGGER.error("Bad parameter '{} {}' , {}", badConfig.getParamName(), badConfig.getParamValue(), badConfig.getMessage(), badConfig);
-            } else {
-                LOGGER.error("Bad config {}", badConfig.getMessage(), badConfig);
-            }
-        } catch (ProcessExecutionException badLaunch) {
-            LOGGER.warn(badLaunch.getMessage(), badLaunch);
-        } catch (Exception exc) {
-            LOGGER.error(exc.getMessage(), exc);
-        }
-
-        exitApplication(rc);
-    }
-
-    private void exitApplication(int returnCode) {
-        int computedReturnCode = SpringApplication.exit(context, () -> returnCode);
-        System.exit(computedReturnCode);
+        ConfigurableApplicationContext context = SpringApplication.run(Main.class, args);
+        SchemaSpyRunner schemaSpyRunner = context.getBean(SchemaSpyRunner.class);
+        schemaSpyRunner.run(args);
+        int exitCode = SpringApplication.exit(context, () -> 0);
+        System.exit(exitCode);
     }
 
 }

--- a/src/main/java/org/schemaspy/SchemaSpyConfiguration.java
+++ b/src/main/java/org/schemaspy/SchemaSpyConfiguration.java
@@ -20,19 +20,12 @@
  */
 package org.schemaspy;
 
-import com.beust.jcommander.ParameterException;
 import org.schemaspy.cli.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationArguments;
-import org.springframework.boot.logging.LogLevel;
-import org.springframework.boot.logging.LoggingSystem;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.ConfigurableEnvironment;
 
-import java.lang.invoke.MethodHandles;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -44,61 +37,31 @@ import java.util.Optional;
 @Configuration
 public class SchemaSpyConfiguration {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
     @Autowired
     private ConfigFileArgumentParser configFileArgumentParser;
 
     @Autowired
     private PropertyFileDefaultProviderFactory factory;
 
-    @Autowired
-    private LoggingSystem loggingSystem;
+    @Bean
+    public CommandLineArguments commandLineArguments() {
+        return new CommandLineArguments();
+    }
 
     @Bean
-    public CommandLineArgumentParser commandLineArgumentParser(ApplicationArguments applicationArguments) {
+    public CommandLineArgumentParser commandLineArgumentParser(ApplicationArguments applicationArguments, CommandLineArguments commandLineArguments) {
         Objects.requireNonNull(applicationArguments);
 
         String[] args = applicationArguments.getSourceArgs();
 
         Objects.requireNonNull(args);
         Optional<PropertyFileDefaultProvider> propertyFileDefaultProvider = findDefaultProvider(args);
-        return new CommandLineArgumentParser(propertyFileDefaultProvider.orElse(null));
+        return new CommandLineArgumentParser(commandLineArguments, propertyFileDefaultProvider.orElse(null));
     }
 
     private Optional<PropertyFileDefaultProvider> findDefaultProvider(String... args) {
         Optional<String> configFileName = configFileArgumentParser.parseConfigFileArgumentValue(args);
         return factory.create(configFileName.orElse(null));
-    }
-
-    @Bean
-    public CommandLineArguments commandLineArguments(ApplicationArguments applicationArguments, CommandLineArgumentParser commandLineArgumentParser, ConfigurableEnvironment environment) {
-        Objects.requireNonNull(applicationArguments);
-        Objects.requireNonNull(commandLineArgumentParser);
-
-        String[] args = applicationArguments.getSourceArgs();
-        Objects.requireNonNull(args);
-
-        CommandLineArguments arguments = parseArgumentsOrExit(commandLineArgumentParser, args);
-        if (arguments.isDebug()) {
-            enableDebug();
-        }
-        return arguments;
-    }
-
-    private CommandLineArguments parseArgumentsOrExit(CommandLineArgumentParser commandLineArgumentParser, String... args) {
-        try {
-            return commandLineArgumentParser.parse(args);
-        } catch (ParameterException e) {
-            LOGGER.error(e.getLocalizedMessage());
-            System.exit(1);
-            return null;
-        }
-    }
-
-    public void enableDebug() {
-        loggingSystem.setLogLevel("org.schemaspy", LogLevel.DEBUG);
-        LOGGER.debug("Debug enabled");
     }
 
 }

--- a/src/main/java/org/schemaspy/cli/CommandLineArgumentParser.java
+++ b/src/main/java/org/schemaspy/cli/CommandLineArgumentParser.java
@@ -51,13 +51,17 @@ public class CommandLineArgumentParser {
 
     private final JCommander jCommander;
 
+    private final CommandLineArguments arguments;
+
     private final PropertyFileDefaultProvider defaultProvider;
 
     private static final String[] requiredFields = {"outputDirectory"};
 
-    public CommandLineArgumentParser(PropertyFileDefaultProvider defaultProvider) {
+    public CommandLineArgumentParser(CommandLineArguments arguments, PropertyFileDefaultProvider defaultProvider) {
         this.defaultProvider = defaultProvider;
+        this.arguments = arguments;
         jCommander = createJCommander();
+        jCommander.addObject(arguments);
     }
 
     private JCommander createJCommander() {
@@ -70,9 +74,6 @@ public class CommandLineArgumentParser {
     }
 
     public CommandLineArguments parse(String... localArgs) {
-        CommandLineArguments arguments = new CommandLineArguments();
-        jCommander.addObject(arguments);
-
         jCommander.parse(localArgs);
 
         if (shouldValidate()) {

--- a/src/main/java/org/schemaspy/cli/SchemaSpyRunner.java
+++ b/src/main/java/org/schemaspy/cli/SchemaSpyRunner.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2018 Nils Petzaell
+ *
+ * This file is part of SchemaSpy.
+ *
+ * SchemaSpy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SchemaSpy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with SchemaSpy. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.schemaspy.cli;
+
+import com.beust.jcommander.ParameterException;
+import org.schemaspy.Config;
+import org.schemaspy.SchemaAnalyzer;
+import org.schemaspy.model.ConnectionFailure;
+import org.schemaspy.model.EmptySchemaException;
+import org.schemaspy.model.InvalidConfigurationException;
+import org.schemaspy.model.ProcessExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ExitCodeGenerator;
+import org.springframework.boot.logging.LogLevel;
+import org.springframework.boot.logging.LoggingSystem;
+import org.springframework.stereotype.Component;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+
+@Component
+public class SchemaSpyRunner implements ExitCodeGenerator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final int EXIT_CODE_OK = 0;
+    private static final int EXIT_CODE_GENERIC_ERROR = 1;
+    private static final int EXIT_CODE_EMPTY_SCHEMA = 2;
+    private static final int EXIT_CODE_CONNECTION_ERROR = 3;
+
+    @Autowired
+    private SchemaAnalyzer analyzer;
+
+    @Autowired
+    private CommandLineArguments arguments;
+
+    @Autowired
+    private CommandLineArgumentParser commandLineArgumentParser;
+
+    @Autowired
+    private LoggingSystem loggingSystem;
+
+    private int exitCode = EXIT_CODE_OK;
+
+    public void run(String... args) {
+        try {
+            commandLineArgumentParser.parse(args);
+        } catch (ParameterException e) {
+            LOGGER.error(e.getLocalizedMessage(),e);
+            exitCode = 1;
+            return;
+        }
+        if (arguments.isHelpRequired()) {
+            commandLineArgumentParser.printUsage();
+            return;
+        }
+
+        if (arguments.isDbHelpRequired()) {
+            commandLineArgumentParser.printDatabaseTypesHelp();
+            return;
+        }
+
+        if (arguments.isDebug()) {
+            enableDebug();
+        }
+
+        runAnalyzer(args);
+    }
+
+    public void enableDebug() {
+        loggingSystem.setLogLevel("org.schemaspy", LogLevel.DEBUG);
+        LOGGER.debug("Debug enabled");
+    }
+
+    private void runAnalyzer(String... args) {
+        exitCode = EXIT_CODE_GENERIC_ERROR;
+        try {
+            exitCode = analyzer.analyze(new Config(args)) == null ? EXIT_CODE_GENERIC_ERROR : EXIT_CODE_OK;
+        } catch (ConnectionFailure couldntConnect) {
+            LOGGER.warn("Connection Failure", couldntConnect);
+            exitCode = EXIT_CODE_CONNECTION_ERROR;
+        } catch (EmptySchemaException noData) {
+            LOGGER.warn("Empty schema", noData);
+            exitCode = EXIT_CODE_EMPTY_SCHEMA;
+        } catch (InvalidConfigurationException badConfig) {
+            LOGGER.debug("Command line parameters: {}", Arrays.asList(args));
+            if (badConfig.getParamName() != null) {
+                LOGGER.error("Bad parameter '{} {}' , {}", badConfig.getParamName(), badConfig.getParamValue(), badConfig.getMessage(), badConfig);
+            } else {
+                LOGGER.error("Bad config {}", badConfig.getMessage(), badConfig);
+            }
+        } catch (ProcessExecutionException badLaunch) {
+            LOGGER.warn(badLaunch.getMessage(), badLaunch);
+        } catch (Exception exc) {
+            LOGGER.error(exc.getMessage(), exc);
+        }
+    }
+
+    @Override
+    public int getExitCode() {
+        return exitCode;
+    }
+}

--- a/src/test/java/org/schemaspy/MainTest.java
+++ b/src/test/java/org/schemaspy/MainTest.java
@@ -1,27 +1,16 @@
 package org.schemaspy;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.schemaspy.model.ConnectionFailure;
-import org.schemaspy.model.Database;
-import org.schemaspy.model.EmptySchemaException;
 import org.schemaspy.testing.ExitCodeRule;
-import org.springframework.boot.DefaultApplicationArguments;
-import org.springframework.boot.logging.logback.LogbackLoggingSystem;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import java.io.IOException;
-import java.sql.SQLException;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 public class MainTest {
 
     @Rule
@@ -32,57 +21,19 @@ public class MainTest {
 
     private SchemaAnalyzer schemaAnalyzer = mock(SchemaAnalyzer.class);
 
-    @Before
-    public void setupContext() {
-        annotationConfigApplicationContext.getDefaultListableBeanFactory().registerSingleton("schemaAnalyzer", schemaAnalyzer);
-        annotationConfigApplicationContext.getDefaultListableBeanFactory().registerSingleton("loggingSystem", new LogbackLoggingSystem(ClassLoader.getSystemClassLoader()));
-        annotationConfigApplicationContext.getDefaultListableBeanFactory().registerSingleton("applicationArguments", new DefaultApplicationArguments(new String [] {"-o", "target/mainTest", "-sso"}));
-        annotationConfigApplicationContext.scan("org.schemaspy.cli");
-        annotationConfigApplicationContext.register(SchemaSpyConfiguration.class);
-        annotationConfigApplicationContext.refresh();
-    }
-
     @Test
-    public void ioExceptionExitCode_1() throws IOException, SQLException {
-        when(schemaAnalyzer.analyze(any(Config.class))).thenThrow(new IOException("file permission error"));
-        Main main = new Main();
-        annotationConfigApplicationContext.getAutowireCapableBeanFactory().autowireBean(main);
-        ignoreSecurityException(()->main.run("-o", "target/mainTest", "-sso"));
-        assertThat(exitCodeRule.getExitCode()).isEqualTo(1);
-    }
-
-    @Test
-    public void emptySchemaExitCode_2() throws IOException, SQLException {
-        when(schemaAnalyzer.analyze(any(Config.class))).thenThrow(new EmptySchemaException());
-        Main main = new Main();
-        annotationConfigApplicationContext.getAutowireCapableBeanFactory().autowireBean(main);
-        ignoreSecurityException(()->main.run("-o", "target/mainTest", "-sso"));
-        assertThat(exitCodeRule.getExitCode()).isEqualTo(2);
-    }
-
-    @Test
-    public void connectionFailureExitCode_3() throws IOException, SQLException {
-        when(schemaAnalyzer.analyze(any(Config.class))).thenThrow(new ConnectionFailure("failed to connect"));
-        Main main = new Main();
-        annotationConfigApplicationContext.getAutowireCapableBeanFactory().autowireBean(main);
-        ignoreSecurityException(()->main.run("-o", "target/mainTest", "-sso"));
-        assertThat(exitCodeRule.getExitCode()).isEqualTo(3);
-    }
-
-    @Test
-    public void returnsNoneNullExitCode_0() throws IOException, SQLException {
-        Database database = mock(Database.class);
-        when(schemaAnalyzer.analyze(any(Config.class))).thenReturn(database);
-        Main main = new Main();
-        annotationConfigApplicationContext.getAutowireCapableBeanFactory().autowireBean(main);
-        ignoreSecurityException(()->main.run("-o", "target/mainTest", "-sso"));
-        assertThat(exitCodeRule.getExitCode()).isEqualTo(0);
-    }
-
-    private void ignoreSecurityException(Runnable runnable) {
+    public void callsSystemExit() {
         try {
-            runnable.run();
-        } catch (SecurityException ignore) {}
+            Main.main(
+                    "-t", "mysql",
+                    "-sso",
+                    "-o", "target/tmp",
+                    "-host", "localhost",
+                    "-port", "123154",
+                    "-db", "qwerty"
+            );
+        } catch (SecurityException ignore) { }
+        assertThat(exitCodeRule.getExitCode()).isEqualTo(3);
     }
 
 }

--- a/src/test/java/org/schemaspy/MainTest.java
+++ b/src/test/java/org/schemaspy/MainTest.java
@@ -1,0 +1,88 @@
+package org.schemaspy;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.schemaspy.model.ConnectionFailure;
+import org.schemaspy.model.Database;
+import org.schemaspy.model.EmptySchemaException;
+import org.schemaspy.testing.ExitCodeRule;
+import org.springframework.boot.DefaultApplicationArguments;
+import org.springframework.boot.logging.logback.LogbackLoggingSystem;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class MainTest {
+
+    @Rule
+    public ExitCodeRule exitCodeRule = new ExitCodeRule();
+
+    private AnnotationConfigApplicationContext annotationConfigApplicationContext =
+            new AnnotationConfigApplicationContext();
+
+    private SchemaAnalyzer schemaAnalyzer = mock(SchemaAnalyzer.class);
+
+    @Before
+    public void setupContext() {
+        annotationConfigApplicationContext.getDefaultListableBeanFactory().registerSingleton("schemaAnalyzer", schemaAnalyzer);
+        annotationConfigApplicationContext.getDefaultListableBeanFactory().registerSingleton("loggingSystem", new LogbackLoggingSystem(ClassLoader.getSystemClassLoader()));
+        annotationConfigApplicationContext.getDefaultListableBeanFactory().registerSingleton("applicationArguments", new DefaultApplicationArguments(new String [] {"-o", "target/mainTest", "-sso"}));
+        annotationConfigApplicationContext.scan("org.schemaspy.cli");
+        annotationConfigApplicationContext.register(SchemaSpyConfiguration.class);
+        annotationConfigApplicationContext.refresh();
+    }
+
+    @Test
+    public void ioExceptionExitCode_1() throws IOException, SQLException {
+        when(schemaAnalyzer.analyze(any(Config.class))).thenThrow(new IOException("file permission error"));
+        Main main = new Main();
+        annotationConfigApplicationContext.getAutowireCapableBeanFactory().autowireBean(main);
+        ignoreSecurityException(()->main.run("-o", "target/mainTest", "-sso"));
+        assertThat(exitCodeRule.getExitCode()).isEqualTo(1);
+    }
+
+    @Test
+    public void emptySchemaExitCode_2() throws IOException, SQLException {
+        when(schemaAnalyzer.analyze(any(Config.class))).thenThrow(new EmptySchemaException());
+        Main main = new Main();
+        annotationConfigApplicationContext.getAutowireCapableBeanFactory().autowireBean(main);
+        ignoreSecurityException(()->main.run("-o", "target/mainTest", "-sso"));
+        assertThat(exitCodeRule.getExitCode()).isEqualTo(2);
+    }
+
+    @Test
+    public void connectionFailureExitCode_3() throws IOException, SQLException {
+        when(schemaAnalyzer.analyze(any(Config.class))).thenThrow(new ConnectionFailure("failed to connect"));
+        Main main = new Main();
+        annotationConfigApplicationContext.getAutowireCapableBeanFactory().autowireBean(main);
+        ignoreSecurityException(()->main.run("-o", "target/mainTest", "-sso"));
+        assertThat(exitCodeRule.getExitCode()).isEqualTo(3);
+    }
+
+    @Test
+    public void returnsNoneNullExitCode_0() throws IOException, SQLException {
+        Database database = mock(Database.class);
+        when(schemaAnalyzer.analyze(any(Config.class))).thenReturn(database);
+        Main main = new Main();
+        annotationConfigApplicationContext.getAutowireCapableBeanFactory().autowireBean(main);
+        ignoreSecurityException(()->main.run("-o", "target/mainTest", "-sso"));
+        assertThat(exitCodeRule.getExitCode()).isEqualTo(0);
+    }
+
+    private void ignoreSecurityException(Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (SecurityException ignore) {}
+    }
+
+}

--- a/src/test/java/org/schemaspy/cli/CommandLineArgumentParserTest.java
+++ b/src/test/java/org/schemaspy/cli/CommandLineArgumentParserTest.java
@@ -40,7 +40,7 @@ public class CommandLineArgumentParserTest {
 
     @Test
     public void givenNoRequiredParameterProvided_AndNoDefaultProvider_ExpectError() {
-        CommandLineArgumentParser parser = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER);
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(), NO_DEFAULT_PROVIDER);
 
         assertThatThrownBy(parser::parse)
                 .isInstanceOf(ParameterException.class)
@@ -52,7 +52,7 @@ public class CommandLineArgumentParserTest {
         PropertyFileDefaultProvider defaultProvider = mock(PropertyFileDefaultProvider.class);
         given(defaultProvider.getDefaultValueFor(any())).willReturn(null);
 
-        CommandLineArgumentParser parser = new CommandLineArgumentParser(defaultProvider);
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(), defaultProvider);
 
         assertThatThrownBy(parser::parse)
                 .isInstanceOf(ParameterException.class)
@@ -68,7 +68,7 @@ public class CommandLineArgumentParserTest {
                 "-o", "aFolder",
                 "-u", "MyUser"
         };
-        CommandLineArgumentParser parser = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER);
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(), NO_DEFAULT_PROVIDER);
 
         CommandLineArguments arguments = parser.parse(args);
 
@@ -82,7 +82,7 @@ public class CommandLineArgumentParserTest {
         given(defaultProvider.getDefaultValueFor("schemaspy.outputDirectory")).willReturn("mydirectory");
         given(defaultProvider.getDefaultValueFor("schemaspy.user")).willReturn("myuser");
 
-        CommandLineArgumentParser parser = new CommandLineArgumentParser(defaultProvider);
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(), defaultProvider);
 
         CommandLineArguments commandLineArguments = parser.parse();
 
@@ -96,7 +96,7 @@ public class CommandLineArgumentParserTest {
                 "-o", "aFolder",
                 "-sso"
         };
-        CommandLineArgumentParser parser = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER);
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(), NO_DEFAULT_PROVIDER);
 
         CommandLineArguments arguments = parser.parse(args);
 
@@ -110,7 +110,7 @@ public class CommandLineArgumentParserTest {
         given(defaultProvider.getDefaultValueFor("schemaspy.outputDirectory")).willReturn("mydirectory");
         given(defaultProvider.getDefaultValueFor("schemaspy.sso")).willReturn(Boolean.TRUE.toString());
 
-        CommandLineArgumentParser parser = new CommandLineArgumentParser(defaultProvider);
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(), defaultProvider);
 
         CommandLineArguments commandLineArguments = parser.parse();
 
@@ -125,7 +125,7 @@ public class CommandLineArgumentParserTest {
                 "-o", "aFolder",
                 "-sso"
         };
-        CommandLineArgumentParser parser = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER);
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(), NO_DEFAULT_PROVIDER);
 
         CommandLineArguments arguments = parser.parse(args);
         parser.printUsage();
@@ -137,7 +137,7 @@ public class CommandLineArgumentParserTest {
         String[] args = {
                 "-help"
         };
-        CommandLineArgumentParser parser = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER);
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(), NO_DEFAULT_PROVIDER);
         CommandLineArguments arguments = parser.parse(args);
         assertThat(arguments.isHelpRequired()).isTrue();
     }
@@ -147,7 +147,7 @@ public class CommandLineArgumentParserTest {
         String[] args = {
                 "-dbHelp"
         };
-        CommandLineArgumentParser parser = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER);
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(), NO_DEFAULT_PROVIDER);
         CommandLineArguments arguments = parser.parse(args);
         assertThat(arguments.isDbHelpRequired()).isTrue();
     }
@@ -157,7 +157,7 @@ public class CommandLineArgumentParserTest {
         String[] args = {
                 "--license"
         };
-        CommandLineArgumentParser parser = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER);
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(), NO_DEFAULT_PROVIDER);
         CommandLineArguments arguments = parser.parse(args);
         assertThat(arguments.isPrintLicense()).isTrue();
     }
@@ -165,7 +165,7 @@ public class CommandLineArgumentParserTest {
     @Test
     @Logger(CommandLineArgumentParser.class)
     public void canPrintLicense() {
-        CommandLineArgumentParser parser = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER);
+        CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(), NO_DEFAULT_PROVIDER);
         parser.printLicense();
         String log = loggingRule.getLog();
         assertThat(log).contains("GNU GENERAL PUBLIC LICENSE");

--- a/src/test/java/org/schemaspy/cli/SchemaSpyRunnerTest.java
+++ b/src/test/java/org/schemaspy/cli/SchemaSpyRunnerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2018 Nils Petzaell
+ *
+ * This file is part of SchemaSpy.
+ *
+ * SchemaSpy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SchemaSpy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with SchemaSpy. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.schemaspy.cli;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.schemaspy.Config;
+import org.schemaspy.SchemaAnalyzer;
+import org.schemaspy.model.ConnectionFailure;
+import org.schemaspy.model.Database;
+import org.schemaspy.model.EmptySchemaException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class SchemaSpyRunnerTest {
+
+    private static final String[] args = {
+            "-t","mysql",
+            "-o","target/tmp",
+            "-sso"};
+
+    @MockBean
+    private SchemaAnalyzer schemaAnalyzer;
+
+    @Autowired
+    private SchemaSpyRunner schemaSpyRunner;
+
+    @Test
+    @DirtiesContext
+    public void ioExceptionExitCode_1() throws IOException, SQLException {
+        when(schemaAnalyzer.analyze(any(Config.class))).thenThrow(new IOException("file permission error"));
+        schemaSpyRunner.run(args);
+        assertThat(schemaSpyRunner.getExitCode()).isEqualTo(1);
+    }
+
+    @Test
+    @DirtiesContext
+    public void emptySchemaExitCode_2() throws IOException, SQLException {
+        when(schemaAnalyzer.analyze(any(Config.class))).thenThrow(new EmptySchemaException());
+        schemaSpyRunner.run(args);
+        assertThat(schemaSpyRunner.getExitCode()).isEqualTo(2);
+    }
+
+    @Test
+    @DirtiesContext
+    public void connectionFailureExitCode_3() throws IOException, SQLException {
+        when(schemaAnalyzer.analyze(any(Config.class))).thenThrow(new ConnectionFailure("failed to connect"));
+        schemaSpyRunner.run(args);
+        assertThat(schemaSpyRunner.getExitCode()).isEqualTo(3);
+    }
+
+    @Test
+    @DirtiesContext
+    public void returnsNoneNullExitCode_0() throws IOException, SQLException {
+        Database database = mock(Database.class);
+        when(schemaAnalyzer.analyze(any(Config.class))).thenReturn(database);
+        schemaSpyRunner.run(args);
+        assertThat(schemaSpyRunner.getExitCode()).isEqualTo(0);
+    }
+}

--- a/src/test/java/org/schemaspy/integrationtesting/StackTraceLoggingIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/StackTraceLoggingIT.java
@@ -18,78 +18,42 @@
  */
 package org.schemaspy.integrationtesting;
 
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.schemaspy.Main;
-import org.schemaspy.logging.LogLevelConditionalThrowableProxyConverter;
+import org.schemaspy.cli.SchemaSpyRunner;
 import org.schemaspy.testing.Logger;
 import org.schemaspy.testing.LoggingRule;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.ApplicationArguments;
-import org.springframework.boot.DefaultApplicationArguments;
 import org.springframework.boot.logging.LogLevel;
 import org.springframework.boot.logging.LoggingSystem;
-import org.springframework.boot.logging.logback.LogbackLoggingSystem;
-import org.springframework.boot.test.context.ConfigFileApplicationContextInitializer;
-import org.springframework.context.annotation.Bean;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
-import org.springframework.test.context.support.DirtiesContextBeforeModesTestExecutionListener;
-import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Nils Petzaell
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = {Main.class, StackTraceLoggingIT.StackTraceLoggingConfiguration.class},
-        initializers = ConfigFileApplicationContextInitializer.class)
-@TestExecutionListeners({DependencyInjectionTestExecutionListener.class,DirtiesContextBeforeModesTestExecutionListener.class,DirtiesContextTestExecutionListener.class})
+@RunWith(SpringRunner.class)
+@SpringBootTest
 public class StackTraceLoggingIT {
-
-    static class StackTraceLoggingConfiguration {
-
-        @Bean
-        public ApplicationArguments applicationArguments(){
-            return new DefaultApplicationArguments(new String[] {"-sso","-o","somefolder", "-t", "doesnt-exist"});
-        }
-
-        @Bean
-        public LoggingSystem loggingSystem() {
-            return new LogbackLoggingSystem(ClassLoader.getSystemClassLoader());
-        }
-    }
-
-    @BeforeClass
-    public static void fakeListener() {
-        LogLevelConditionalThrowableProxyConverter logLevelConditionalThrowableProxyConverter = new LogLevelConditionalThrowableProxyConverter();
-        logLevelConditionalThrowableProxyConverter.onApplicationEvent(null);
-    }
 
     @Rule
     public LoggingRule loggingRule = new LoggingRule();
 
     @Autowired
-    private Main main;
-
-    @Autowired
-    private ApplicationArguments applicationArguments;
+    private SchemaSpyRunner schemaSpyRunner;
 
     @Autowired
     private LoggingSystem loggingSystem;
 
     @Test
     @DirtiesContext
-    @Logger(value = Main.class, pattern = "%clr(%-5level) - %msg%n%debugEx")
+    @Logger(value = SchemaSpyRunner.class, pattern = "%clr(%-5level) - %msg%n%debugEx")
     public void noStacktraceWhenLoggingIsOf() {
-        loggingSystem.setLogLevel("org.schemaspy", LogLevel.INFO);
-        main.run(applicationArguments.getSourceArgs());
+        schemaSpyRunner.run(new String[] {"-sso","-o","somefolder", "-t", "doesnt-exist"});
         String log = loggingRule.getLog();
         assertThat(log).isNotEmpty();
         assertThat(log).doesNotContain("Caused by: org.schemaspy.db.config.ResourceNotFoundException");
@@ -97,11 +61,10 @@ public class StackTraceLoggingIT {
 
     @Test
     @DirtiesContext
-    @Logger(value = Main.class, pattern = "%clr(%-5level) - %msg%n%debugEx")
+    @Logger(value = SchemaSpyRunner.class, pattern = "%clr(%-5level) - %msg%n%debugEx")
     public void stacktraceWhenLoggingIsOn() {
-        loggingSystem.setLogLevel("org.schemaspy", LogLevel.DEBUG);
         try {
-            main.run(applicationArguments.getSourceArgs());
+            schemaSpyRunner.run(new String[]{"-sso", "-o", "somefolder", "-t", "doesnt-exist", "-debug"});
             String log = loggingRule.getLog();
             assertThat(log).isNotEmpty();
             assertThat(log).contains("Caused by: org.schemaspy.db.config.ResourceNotFoundException");

--- a/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlKeyWordTableIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlKeyWordTableIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.schemaspy.Config;
+import org.schemaspy.cli.CommandLineArgumentParser;
 import org.schemaspy.cli.CommandLineArguments;
 import org.schemaspy.integrationtesting.MysqlSuite;
 import org.schemaspy.model.Database;
@@ -33,14 +34,12 @@ import org.schemaspy.service.DatabaseService;
 import org.schemaspy.service.SqlService;
 import org.schemaspy.testing.SuiteOrTestJdbcContainerRule;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.containers.MySQLContainer;
 
 import javax.script.ScriptException;
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.sql.DatabaseMetaData;
@@ -48,13 +47,13 @@ import java.sql.SQLException;
 
 import static com.github.npetzall.testcontainers.junit.jdbc.JdbcAssumptions.assumeDriverIsPresent;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 /**
  * @author Nils Petzaell
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@DirtiesContext
 public class MysqlKeyWordTableIT {
 
     @Autowired
@@ -66,11 +65,8 @@ public class MysqlKeyWordTableIT {
     @Mock
     private ProgressListener progressListener;
 
-    @MockBean
-    private CommandLineArguments arguments;
-
-    @MockBean
-    private CommandLineRunner commandLineRunner;
+    @Autowired
+    private CommandLineArgumentParser commandLineArgumentParser;
 
     private static Database database;
 
@@ -100,15 +96,11 @@ public class MysqlKeyWordTableIT {
                 "-o", "target/integrationtesting/mysql_keywords",
                 "-u", "test",
                 "-p", "test",
+                "-cat", "%",
                 "-host", jdbcContainerRule.getContainer().getContainerIpAddress(),
                 "-port", jdbcContainerRule.getContainer().getMappedPort(3306).toString()
         };
-        given(arguments.getOutputDirectory()).willReturn(new File("target/integrationtesting/mysql_keywords"));
-        given(arguments.getDatabaseType()).willReturn("mysql");
-        given(arguments.getUser()).willReturn("test");
-        given(arguments.getSchema()).willReturn("keywordtableit");
-        given(arguments.getCatalog()).willReturn("%");
-        given(arguments.getDatabaseName()).willReturn("keywordtableit");
+        CommandLineArguments arguments = commandLineArgumentParser.parse(args);
         Config config = new Config(args);
         DatabaseMetaData databaseMetaData = sqlService.connect(config);
         Database database = new Database(

--- a/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlRoutinesIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlRoutinesIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.schemaspy.Config;
+import org.schemaspy.cli.CommandLineArgumentParser;
 import org.schemaspy.cli.CommandLineArguments;
 import org.schemaspy.integrationtesting.MysqlSuite;
 import org.schemaspy.model.Database;
@@ -33,26 +34,24 @@ import org.schemaspy.service.DatabaseService;
 import org.schemaspy.service.SqlService;
 import org.schemaspy.testing.SuiteOrTestJdbcContainerRule;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.containers.MySQLContainer;
 
-import java.io.File;
 import java.io.IOException;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
 import static com.github.npetzall.testcontainers.junit.jdbc.JdbcAssumptions.assumeDriverIsPresent;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 /**
  * @author Nils Petzaell
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@DirtiesContext
 public class MysqlRoutinesIT {
 
     @Autowired
@@ -64,11 +63,8 @@ public class MysqlRoutinesIT {
     @Mock
     private ProgressListener progressListener;
 
-    @MockBean
-    private CommandLineArguments arguments;
-
-    @MockBean
-    private CommandLineRunner commandLineRunner;
+    @Autowired
+    private CommandLineArgumentParser commandLineArgumentParser;
 
     private static Database database;
 
@@ -102,12 +98,7 @@ public class MysqlRoutinesIT {
                 "-host", jdbcContainerRule.getContainer().getContainerIpAddress(),
                 "-port", jdbcContainerRule.getContainer().getMappedPort(3306).toString()
         };
-        given(arguments.getOutputDirectory()).willReturn(new File("target/integrationtesting/mysqlroutines"));
-        given(arguments.getDatabaseType()).willReturn("mysql");
-        given(arguments.getUser()).willReturn("routinesit");
-        given(arguments.getSchema()).willReturn("routinesit");
-        given(arguments.getCatalog()).willReturn("%");
-        given(arguments.getDatabaseName()).willReturn("test");
+        CommandLineArguments arguments = commandLineArgumentParser.parse(args);
         Config config = new Config(args);
         DatabaseMetaData databaseMetaData = sqlService.connect(config);
         Database database = new Database(
@@ -124,7 +115,7 @@ public class MysqlRoutinesIT {
     @Test
     public void databaseShouldExist() {
         assertThat(database).isNotNull();
-        assertThat(database.getName()).isEqualToIgnoringCase("test");
+        assertThat(database.getName()).isEqualToIgnoringCase("routinesit");
     }
 
     @Test

--- a/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlSpacesIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlSpacesIT.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.schemaspy.Config;
+import org.schemaspy.cli.CommandLineArgumentParser;
 import org.schemaspy.cli.CommandLineArguments;
 import org.schemaspy.integrationtesting.MysqlSuite;
 import org.schemaspy.model.*;
@@ -33,14 +34,12 @@ import org.schemaspy.service.DatabaseService;
 import org.schemaspy.service.SqlService;
 import org.schemaspy.testing.SuiteOrTestJdbcContainerRule;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.containers.MySQLContainer;
 
 import javax.script.ScriptException;
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.sql.DatabaseMetaData;
@@ -48,13 +47,13 @@ import java.sql.SQLException;
 
 import static com.github.npetzall.testcontainers.junit.jdbc.JdbcAssumptions.assumeDriverIsPresent;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 /**
  * @author Nils Petzaell
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@DirtiesContext
 @Ignore
 /*
  https://github.com/schemaspy/schemaspy/pull/174#issuecomment-352158979
@@ -72,11 +71,8 @@ public class MysqlSpacesIT {
     @Mock
     private ProgressListener progressListener;
 
-    @MockBean
-    private CommandLineArguments arguments;
-
-    @MockBean
-    private CommandLineRunner commandLineRunner;
+    @Autowired
+    private CommandLineArgumentParser commandLineArgumentParser;
 
     private static Database database;
 
@@ -110,12 +106,7 @@ public class MysqlSpacesIT {
                 "-host", jdbcContainerRule.getContainer().getContainerIpAddress(),
                 "-port", jdbcContainerRule.getContainer().getMappedPort(3306).toString()
         };
-        given(arguments.getOutputDirectory()).willReturn(new File("target/integrationtesting/mysql_spaces"));
-        given(arguments.getDatabaseType()).willReturn("mysql");
-        given(arguments.getUser()).willReturn("test");
-        given(arguments.getSchema()).willReturn("TEST 1.0");
-        given(arguments.getCatalog()).willReturn("%");
-        given(arguments.getDatabaseName()).willReturn("TEST 1.0");
+        CommandLineArguments arguments = commandLineArgumentParser.parse(args);
         Config config = new Config(args);
         DatabaseMetaData databaseMetaData = sqlService.connect(config);
         Database database = new Database(

--- a/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlSpacesNoDotsIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/mysql/MysqlSpacesNoDotsIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.schemaspy.Config;
+import org.schemaspy.cli.CommandLineArgumentParser;
 import org.schemaspy.cli.CommandLineArguments;
 import org.schemaspy.integrationtesting.MysqlSuite;
 import org.schemaspy.model.*;
@@ -32,14 +33,12 @@ import org.schemaspy.service.DatabaseService;
 import org.schemaspy.service.SqlService;
 import org.schemaspy.testing.SuiteOrTestJdbcContainerRule;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.containers.MySQLContainer;
 
 import javax.script.ScriptException;
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.sql.DatabaseMetaData;
@@ -47,13 +46,13 @@ import java.sql.SQLException;
 
 import static com.github.npetzall.testcontainers.junit.jdbc.JdbcAssumptions.assumeDriverIsPresent;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 /**
  * @author Nils Petzaell
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@DirtiesContext
 public class MysqlSpacesNoDotsIT {
 
     @Autowired
@@ -65,11 +64,8 @@ public class MysqlSpacesNoDotsIT {
     @Mock
     private ProgressListener progressListener;
 
-    @MockBean
-    private CommandLineArguments arguments;
-
-    @MockBean
-    private CommandLineRunner commandLineRunner;
+    @Autowired
+    private CommandLineArgumentParser commandLineArgumentParser;
 
     private static Database database;
 
@@ -103,12 +99,7 @@ public class MysqlSpacesNoDotsIT {
                 "-host", jdbcContainerRule.getContainer().getContainerIpAddress(),
                 "-port", jdbcContainerRule.getContainer().getMappedPort(3306).toString()
         };
-        given(arguments.getOutputDirectory()).willReturn(new File("target/integrationtesting/mysql_spaces_no_dots"));
-        given(arguments.getDatabaseType()).willReturn("mysql");
-        given(arguments.getUser()).willReturn("test");
-        given(arguments.getSchema()).willReturn("TEST 1");
-        given(arguments.getCatalog()).willReturn("%");
-        given(arguments.getDatabaseName()).willReturn("TEST 1");
+        CommandLineArguments arguments = commandLineArgumentParser.parse(args);
         Config config = new Config(args);
         DatabaseMetaData databaseMetaData = sqlService.connect(config);
         Database database = new Database(

--- a/src/test/java/org/schemaspy/testcontainer/InformixIndexIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/InformixIndexIT.java
@@ -27,32 +27,31 @@ import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.schemaspy.Config;
+import org.schemaspy.cli.CommandLineArgumentParser;
 import org.schemaspy.cli.CommandLineArguments;
 import org.schemaspy.model.*;
 import org.schemaspy.service.DatabaseService;
 import org.schemaspy.service.SqlService;
 import org.schemaspy.testing.AssumeClassIsPresentRule;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.containers.InformixContainer;
 
-import java.io.File;
 import java.io.IOException;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
 import static com.github.npetzall.testcontainers.junit.jdbc.JdbcAssumptions.assumeDriverIsPresent;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 /**
  * @author Nils Petzaell
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@DirtiesContext
 public class InformixIndexIT {
     @Autowired
     private SqlService sqlService;
@@ -63,11 +62,8 @@ public class InformixIndexIT {
     @Mock
     private ProgressListener progressListener;
 
-    @MockBean
-    private CommandLineArguments arguments;
-
-    @MockBean
-    private CommandLineRunner commandLineRunner;
+    @Autowired
+    private CommandLineArgumentParser commandLineArgumentParser;
 
     private static Database database;
 
@@ -104,12 +100,7 @@ public class InformixIndexIT {
                 "-host", jdbcContainerRule.getContainer().getContainerIpAddress(),
                 "-port", jdbcContainerRule.getContainer().getJdbcPort().toString()
         };
-        given(arguments.getOutputDirectory()).willReturn(new File("target/integrationtesting/informix"));
-        given(arguments.getDatabaseType()).willReturn("informix");
-        given(arguments.getUser()).willReturn(jdbcContainerRule.getContainer().getUsername());
-        given(arguments.getSchema()).willReturn("informix");
-        given(arguments.getCatalog()).willReturn("test");
-        given(arguments.getDatabaseName()).willReturn("test");
+        CommandLineArguments arguments = commandLineArgumentParser.parse(args);
         Config config = new Config(args);
         DatabaseMetaData databaseMetaData = sqlService.connect(config);
         Database database = new Database(

--- a/src/test/java/org/schemaspy/testcontainer/MSSQLServerIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/MSSQLServerIT.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.schemaspy.Config;
+import org.schemaspy.cli.CommandLineArgumentParser;
 import org.schemaspy.cli.CommandLineArguments;
 import org.schemaspy.model.Database;
 import org.schemaspy.model.ProgressListener;
@@ -34,14 +35,12 @@ import org.schemaspy.model.TableColumn;
 import org.schemaspy.service.DatabaseService;
 import org.schemaspy.service.SqlService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.containers.MSSQLServerContainer;
 
 import javax.script.ScriptException;
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.sql.DatabaseMetaData;
@@ -49,7 +48,6 @@ import java.sql.SQLException;
 
 import static com.github.npetzall.testcontainers.junit.jdbc.JdbcAssumptions.assumeDriverIsPresent;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 /**
  * @author Rafal Kasa
@@ -57,6 +55,7 @@ import static org.mockito.BDDMockito.given;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@DirtiesContext
 public class MSSQLServerIT {
 
     @Autowired
@@ -68,11 +67,8 @@ public class MSSQLServerIT {
     @Mock
     private ProgressListener progressListener;
 
-    @MockBean
-    private CommandLineArguments arguments;
-
-    @MockBean
-    private CommandLineRunner commandLineRunner;
+    @Autowired
+    private CommandLineArgumentParser commandLineArgumentParser;
 
     private static Database database;
 
@@ -102,12 +98,7 @@ public class MSSQLServerIT {
                 "-host", jdbcContainerRule.getContainer().getContainerIpAddress(),
                 "-port", jdbcContainerRule.getContainer().getMappedPort(1433).toString()
         };
-        given(arguments.getOutputDirectory()).willReturn(new File("target/integrationtesting/mssql"));
-        given(arguments.getDatabaseType()).willReturn("mssql08");
-        given(arguments.getUser()).willReturn("sa");
-        given(arguments.getSchema()).willReturn("dbo");
-        given(arguments.getCatalog()).willReturn("%");
-        given(arguments.getDatabaseName()).willReturn("test");
+        CommandLineArguments arguments = commandLineArgumentParser.parse(args);
         Config config = new Config(args);
         DatabaseMetaData databaseMetaData = sqlService.connect(config);
         Database database = new Database(

--- a/src/test/java/org/schemaspy/testcontainer/OracleIT.java
+++ b/src/test/java/org/schemaspy/testcontainer/OracleIT.java
@@ -27,6 +27,7 @@ import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.schemaspy.Config;
+import org.schemaspy.cli.CommandLineArgumentParser;
 import org.schemaspy.cli.CommandLineArguments;
 import org.schemaspy.model.Database;
 import org.schemaspy.model.ProgressListener;
@@ -36,14 +37,12 @@ import org.schemaspy.service.DatabaseService;
 import org.schemaspy.service.SqlService;
 import org.schemaspy.testing.AssumeClassIsPresentRule;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.containers.OracleContainer;
 
 import javax.script.ScriptException;
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.sql.DatabaseMetaData;
@@ -51,13 +50,13 @@ import java.sql.SQLException;
 
 import static com.github.npetzall.testcontainers.junit.jdbc.JdbcAssumptions.assumeDriverIsPresent;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 
 /**
  * @author Nils Petzaell
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@DirtiesContext
 public class OracleIT {
 
     @Autowired
@@ -69,11 +68,8 @@ public class OracleIT {
     @Mock
     private ProgressListener progressListener;
 
-    @MockBean
-    private CommandLineArguments arguments;
-
-    @MockBean
-    private CommandLineRunner commandLineRunner;
+    @Autowired
+    private CommandLineArgumentParser commandLineArgumentParser;
 
     private static Database database;
 
@@ -109,12 +105,7 @@ public class OracleIT {
                 "-host", jdbcContainerRule.getContainer().getContainerIpAddress(),
                 "-port", jdbcContainerRule.getContainer().getOraclePort().toString()
         };
-        given(arguments.getOutputDirectory()).willReturn(new File("target/integrationtesting/databaseServiceIT"));
-        given(arguments.getDatabaseType()).willReturn("orathin");
-        given(arguments.getUser()).willReturn("orait");
-        given(arguments.getSchema()).willReturn("ORAIT");
-        given(arguments.getCatalog()).willReturn("%");
-        given(arguments.getDatabaseName()).willReturn(jdbcContainerRule.getContainer().getSid());
+        CommandLineArguments arguments = commandLineArgumentParser.parse(args);
         Config config = new Config(args);
         DatabaseMetaData databaseMetaData = sqlService.connect(config);
         Database database = new Database(

--- a/src/test/java/org/schemaspy/testing/ExitCodeRule.java
+++ b/src/test/java/org/schemaspy/testing/ExitCodeRule.java
@@ -1,0 +1,46 @@
+package org.schemaspy.testing;
+
+import org.junit.rules.ExternalResource;
+
+import java.security.Permission;
+
+public class ExitCodeRule extends ExternalResource {
+
+    private SecurityManager securityManager;
+    private int exitCode;
+
+    public int getExitCode() {
+        return exitCode;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        securityManager = System.getSecurityManager();
+        System.setSecurityManager(new ExitPreventionSecurityManager());
+    }
+
+    @Override
+    protected void after() {
+        System.setSecurityManager(securityManager);
+    }
+
+    class ExitPreventionSecurityManager extends SecurityManager {
+
+        @Override
+        public void checkPermission(Permission perm) {
+
+        }
+
+        @Override
+        public void checkPermission(Permission perm, Object context) {
+
+        }
+
+        @Override
+        public void checkExit(int status) {
+            exitCode = status;
+            throw new SecurityException("Exit prevented by ExitCodeRule");
+        }
+    }
+
+}


### PR DESCRIPTION
It closes the SpringContext and evals ExitCodeGenerator so that SpringContext can report an ExitCode. 

But since the returned ExitCode isn't used and we don't use any ExitCodeGenerators and we don't call System.exit with the returned value.

We should probably switch to SpringApplication.close and then use the ReturnCode provided to the exitApplication method in the System.exit call.

First commit with test, proves that there is a problem.
Second commit the fix in production code and tests should be come green.

