### PR TITLE
Move methods only used in DotNode from HtmlFormatter

### DIFF
--- a/src/main/java/org/schemaspy/view/HtmlFormatter.java
+++ b/src/main/java/org/schemaspy/view/HtmlFormatter.java
@@ -21,24 +21,16 @@
  */
 package org.schemaspy.view;
 
-import com.github.mustachejava.util.HtmlEscaper;
 import org.schemaspy.Config;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
-import java.lang.invoke.MethodHandles;
-import java.net.URLEncoder;
 
 /**
  * @author John Currier
  * @author Rafal Kasa
  * @author Thomas Traude
  * @author Daniel Watt
+ * @author Nils Petzaell
  */
 public class HtmlFormatter {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     protected final boolean displayNumRows = Config.getInstance().isNumRowsEnabled();
 
@@ -53,26 +45,5 @@ public class HtmlFormatter {
      */
     protected String getPathToRoot() {
         return "";
-    }
-
-    /**
-     * HTML escape the specified string
-     *
-     * @param string
-     * @return
-     */
-    static String escapeHtml(String string) {
-        StringWriter writer = new StringWriter();
-        HtmlEscaper.escape(string, writer);
-        return writer.toString();
-    }
-
-    static String urlEncodeLink(String string) {
-        try {
-            return URLEncoder.encode(string, Config.DOT_CHARSET).replace("+","%20");
-        } catch (UnsupportedEncodingException e) {
-            LOGGER.info("Error trying to urlEncode string [{}] with encoding [" + Config.DOT_CHARSET + "]", string);
-            return string;
-        }
     }
 }

--- a/src/test/java/org/schemaspy/view/DotNodeTest.java
+++ b/src/test/java/org/schemaspy/view/DotNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Daniel Watt
+ * Copyright (C) 2018 Nils Petzaell
  *
  * This file is part of SchemaSpy.
  *
@@ -19,23 +19,32 @@
 package org.schemaspy.view;
 
 import org.junit.Test;
+import org.schemaspy.model.Database;
+import org.schemaspy.model.LogicalTable;
+import org.schemaspy.model.Table;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
- * @author Daniel Watt
+ * @author Nils Petzaell
  */
-public class HtmlFormatterTest {
+public class DotNodeTest {
 
     @Test
     public void escapeHtml() {
-        assertThat(HtmlFormatter.escapeHtml("string")).isEqualTo("string");
-        assertThat(HtmlFormatter.escapeHtml("string with spaces")).isEqualTo("string with spaces");
+        Database database = mock(Database.class);
+        Table table = new LogicalTable(database, "catalog", "schema", "<table>", "comment");
+        DotNode dotNode = new DotNode(table,"", "output");
+        System.out.println(dotNode.toString());
+        assertThat(dotNode.toString()).contains("tooltip=\"&lt;table&gt;");
     }
 
     @Test
     public void urlEncodeLink() {
-        assertThat(HtmlFormatter.urlEncodeLink("string")).isEqualTo("string");
-        assertThat(HtmlFormatter.urlEncodeLink("string with spaces")).isEqualTo("string%20with%20spaces");
+        Database database = mock(Database.class);
+        Table table = new LogicalTable(database, "catalog", "schema", "a table", "comment");
+        DotNode dotNode = new DotNode(table,"", "output");
+        assertThat(dotNode.toString()).contains("URL=\"a%20table.html\"");
     }
 }


### PR DESCRIPTION
Moved methods only used by DotNode present in HtmlFormatter to DotNode

Updated tests.