### PR TITLE
Fix sqlite.properties for xerial/sqlite-jdbc

### DIFF
--- a/src/main/resources/org/schemaspy/types/sqlite-xerial.properties
+++ b/src/main/resources/org/schemaspy/types/sqlite-xerial.properties
@@ -1,0 +1,15 @@
+#
+# see http://schemaspy.org/dbtypes.html
+# for configuration / customization details
+#
+
+description=SQLite
+
+connectionSpec=jdbc:sqlite:<db>
+db=path to database or :memory:
+
+driver=org.sqlite.JDBC
+
+# Sample path to the SQLite drivers.
+# Use -dp to override.
+driverPath=sqlite.jar


### PR DESCRIPTION
In currently, sqlite JDBC driver that actively maintained is [xerial/sqlite-jdbc](https://github.com/xerial/sqlite-jdbc) and it get information easily. In usage of [bitbucket page](https://bitbucket.org/xerial/sqlite-jdbc), specify driver `org.sqlite.JDBC` instead of `SQLite.JDBCDriver`.

The driver `SQLite.JDBCDriver` might be that [sqlitejdbc](https://github.com/crawshaw/sqlitejdbc) has. But it currently not maintained, can't refer [official page](http://www.zentus.com/sqlitejdbc), and difficulty to get information.

And the driver uses `connectionSpec` to sqlite database file path. Prefixed `/` causes missing the file to specify root of filesystem. So remove it.