### PR TITLE
Primarykeys contains null

### DIFF
--- a/src/main/java/org/schemaspy/service/TableService.java
+++ b/src/main/java/org/schemaspy/service/TableService.java
@@ -681,7 +681,21 @@ public class TableService {
 
         String columnName = rs.getString("COLUMN_NAME");
 
-        table.setPrimaryColumn(table.getColumn(columnName));
+        TableColumn tableColumn = table.getColumn(columnName);
+        if (Objects.nonNull(tableColumn)) {
+            table.setPrimaryColumn(tableColumn);
+        } else {
+            LOGGER.error(
+                    "Found PrimaryKey index '{}' with column '{}.{}.{}.{}'" +
+                    ", but was unable to find column in table '{}'",
+                    pkName,
+                    rs.getString("TABLE_CAT"),
+                    rs.getString("TABLE_SCHEM"),
+                    rs.getString("TABLE_NAME"),
+                    columnName,
+                    table.getFullName()
+            );
+        }
     }
 
     private static void markDownRegistryPage(Table table) {

--- a/src/main/java/org/schemaspy/service/TableService.java
+++ b/src/main/java/org/schemaspy/service/TableService.java
@@ -95,7 +95,7 @@ public class TableService {
      * @param forceQuotes
      * @throws SQLException
      */
-    private void initColumnAutoUpdate(Database db, Table table, boolean forceQuotes) throws SQLException {
+    private static void initColumnAutoUpdate(Database db, Table table, boolean forceQuotes) throws SQLException {
 
         if (table.isView() || table.isRemote())
             return;
@@ -130,7 +130,7 @@ public class TableService {
                 if (!table.isLogical()) {
                     // don't completely choke just because we couldn't do this....
                     LOGGER.warn("Failed to determine auto increment status: {}", exc);
-                    LOGGER.warn("SQL: {}", sql.toString());
+                    LOGGER.warn("SQL: {}", sql);
                 }
             } else {
                 initColumnAutoUpdate(db, table, true);
@@ -138,7 +138,7 @@ public class TableService {
         }
     }
 
-    private TableColumn getColumn(Table table, String columnName) {
+    private static TableColumn getColumn(Table table, String columnName) {
         TableColumn column = table.getColumn(columnName);
         if (Objects.isNull(column)) {
             if (columnName.startsWith(table.getName())) {
@@ -166,7 +166,7 @@ public class TableService {
         }
     }
 
-    private TableColumn initColumn(Table table, ResultSet rs) throws SQLException {
+    private static TableColumn initColumn(Table table, ResultSet rs) throws SQLException {
         TableColumn column = new TableColumn(table);
         // names and types are typically reused *many* times in a database,
         // so keep a single instance of each distinct one
@@ -202,7 +202,7 @@ public class TableService {
 
         column.setAllExcluded(column.matches(excludeColumns));
         column.setExcluded(column.isAllExcluded() || column.matches(excludeIndirectColumns));
-        LOGGER.trace("Excluding column {}" + '.' + "{}: matches {}:{} {}:{}", column.getTable(), column.getName(), excludeColumns, column.isAllExcluded(), excludeIndirectColumns, column.matches(excludeIndirectColumns));
+        LOGGER.trace("Excluding column {}.{}: matches {}:{} {}:{}", column.getTable(), column.getName(), excludeColumns, column.isAllExcluded(), excludeIndirectColumns, column.matches(excludeIndirectColumns));
 
         return column;
     }
@@ -306,7 +306,7 @@ public class TableService {
                     throw sqlExc;
 
                 // otherwise just report the fact that we tried & couldn't
-                System.err.println("Couldn't resolve foreign keys for remote table " + remoteTable.getFullName() + ": " + sqlExc);
+                LOGGER.warn("Couldn't resolve foreign keys for remote table '{}'", remoteTable.getFullName(), sqlExc);
             }
         }
     }
@@ -334,7 +334,7 @@ public class TableService {
         Pattern exclude = Config.getInstance().getTableExclusions();
 
         if (!include.matcher(pkTableName).matches() || exclude.matcher(pkTableName).matches()) {
-            LOGGER.debug("Ignoring {} referenced by FK {}", table.getFullName(db.getName(), pkCatalog, pkSchema, pkTableName), fkName);
+            LOGGER.debug("Ignoring {} referenced by FK {}", Table.getFullName(db.getName(), pkCatalog, pkSchema, pkTableName), fkName);
             return;
         }
 
@@ -359,7 +359,7 @@ public class TableService {
             // if named table doesn't exist in this schema
             // or exists here but really referencing same named table in another schema
             if (parentTable == null || !baseContainer.equals(parentContainer)) {
-                LOGGER.debug("Adding remote table {}", table.getFullName(db.getName(), pkCatalog, pkSchema, pkTableName));
+                LOGGER.debug("Adding remote table {}", Table.getFullName(db.getName(), pkCatalog, pkSchema, pkTableName));
                 parentTable = addRemoteTable(db, pkCatalog, pkSchema, pkTableName, baseContainer, false);
             }
 
@@ -392,7 +392,7 @@ public class TableService {
         } else
             sql.append(db.getQuotedIdentifier(table.getName()));
 
-        LOGGER.trace(sql.toString());
+        LOGGER.trace("Fetch number of rows using sql: '{}'",sql);
         try (PreparedStatement stmt = sqlService.prepareStatement(sql.toString());
              ResultSet rs = stmt.executeQuery()) {
 
@@ -408,7 +408,7 @@ public class TableService {
         }
     }
 
-    private String getSchemaOrCatalog(Database db, Table table, boolean forceQuotes) throws SQLException {
+    private static String getSchemaOrCatalog(Database db, Table table, boolean forceQuotes) throws SQLException {
         String schemaOrCatalog = null;
         if (table.getSchema() != null) {
             schemaOrCatalog = table.getSchema();
@@ -452,6 +452,7 @@ public class TableService {
             } catch (SQLException sqlException) {
                 // don't die just because this failed
                 originalFailure = sqlException;
+                LOGGER.debug("Failed to fetch number of rows for '{}' using custom query: '{}'", table.getFullName(), sql, sqlException);
             }
         }
 
@@ -460,17 +461,16 @@ public class TableService {
             // '*' should work best for the majority of cases
             return fetchNumRows(db, table, "count(*)", false);
         } catch (SQLException try2Exception) {
+            LOGGER.debug("Failed to fetch number of rows for '{}' using built-in query with 'count(*)'", table.getFullName(), try2Exception);
             try {
                 // except nested tables...try using '1' instead
                 return fetchNumRows(db, table, "count(1)", false);
             } catch (SQLException try3Exception) {
                 if (!table.isLogical()) {
-                    LOGGER.warn("Unable to extract the number of rows for table {}, using '-1'", table.getName());
                     if (originalFailure != null)
-                        LOGGER.warn(originalFailure.toString());
-                    LOGGER.warn(try2Exception.toString());
-                    if (!String.valueOf(try2Exception.toString()).equals(try3Exception.toString()))
-                        LOGGER.warn(try3Exception.toString());
+                        LOGGER.warn("Failed to fetch number of rows for '{}' using custom query: '{}'", table.getFullName(), sql, originalFailure);
+                    LOGGER.warn("Failed to fetch number of rows for '{}' using built-in query with 'count(*)'", table.getFullName(), try2Exception);
+                    LOGGER.warn("Failed to fetch number of rows for '{}' using built-in query with 'count(1)'", table.getFullName(), try3Exception);
                 }
                 return -1;
             }
@@ -521,6 +521,7 @@ public class TableService {
                             parent = addRemoteTable(db, fk.getRemoteCatalog(), fk.getRemoteSchema(), fk.getTableName(), table.getContainer(), true);
                         } catch (SQLException exc) {
                             parent = null;
+                            LOGGER.debug("Failed to addRemoteTable '{}.{}.{}'", fk.getRemoteCatalog(), fk.getRemoteSchema(), fk.getTableName(), exc);
                         }
                     } else {
                         parent = tables.get(fk.getTableName());
@@ -530,11 +531,15 @@ public class TableService {
                         TableColumn parentColumn = parent.getColumn(fk.getColumnName());
 
                         if (parentColumn == null) {
-                            LOGGER.warn("Undefined column '{}" + '.' + "{}' referenced by '{}" + '.' + "{}' in XML metadata", parent.getName(), fk.getColumnName(), col.getTable(), col);
+                            LOGGER.warn("Undefined column '{}.{}' referenced by '{}.{}' in XML metadata", parent.getName(), fk.getColumnName(), col.getTable(), col);
                         } else {
                             /**
                              * Merely instantiating a foreign key constraint ties it
                              * into its parent and child columns (& therefore their tables)
+                             */
+                            /* TODO: This sort of code suggest that too much is happening in the constructor.
+                             * Should either be a factory or constructed by a method of the holding object.
+                             * Or opertations preformed in the constructor should be exposed.
                              */
                             @SuppressWarnings("unused")
                             ForeignKeyConstraint unused = new ForeignKeyConstraint(parentColumn, col) {
@@ -546,16 +551,16 @@ public class TableService {
 
                             // they forgot to say it was a primary key
                             if (!parentColumn.isPrimary()) {
-                                LOGGER.warn("Assuming {}" + '.' + "{} is a primary key due to being referenced by {}" + '.' + "{}", parentColumn.getTable(), parentColumn, col.getTable(), col);
+                                LOGGER.warn("Assuming '{}.{}' is a primary key due to being referenced by '{}.{}'", parentColumn.getTable(), parentColumn, col.getTable(), col);
                                 parent.setPrimaryColumn(parentColumn);
                             }
                         }
                     } else {
-                        LOGGER.warn("Undefined table '{}' referenced by '{}" + '.' + "{}' in XML metadata", fk.getTableName(), table.getName(), col.getName());
+                        LOGGER.warn("Undefined table '{}' referenced by '{}.{}' in XML metadata", fk.getTableName(), table.getName(), col.getName());
                     }
                 }
             } else {
-                LOGGER.warn("Undefined column '{}" + '.' + "{}' in XML metadata", table.getName(), colMeta.getName());
+                LOGGER.warn("Undefined column '{}.{}' in XML metadata", table.getName(), colMeta.getName());
             }
         }
     }
@@ -593,7 +598,7 @@ public class TableService {
     //This is to handle a problem with informix and lvarchar Issue 215. It's been reported to IBM.
     //According to DatabaseMetaData.getIndexInfo() ORDINAL_POSITION is zero when type is tableIndexStatistic.
     //Problem with informix is that lvarchar is reported back as TYPE = tableIndexOther and ORDINAL_POSITION = 0.
-    private boolean isIndexRow(ResultSet rs) throws SQLException {
+    private static boolean isIndexRow(ResultSet rs) throws SQLException {
         return rs.getShort("TYPE") != DatabaseMetaData.tableIndexStatistic && rs.getShort("ORDINAL_POSITION") > 0;
     }
 
@@ -615,8 +620,7 @@ public class TableService {
                     addIndex(table, rs);
             }
         } catch (SQLException sqlException) {
-            LOGGER.warn("Failed to query index information with SQL: {}", selectIndexesSql);
-            LOGGER.warn(sqlException.toString());
+            LOGGER.warn("Failed to query index information with SQL: {}", selectIndexesSql, sqlException);
             return false;
         }
 
@@ -627,7 +631,7 @@ public class TableService {
      * @param rs
      * @throws SQLException
      */
-    private void addIndex(Table table, ResultSet rs) throws SQLException {
+    private static void addIndex(Table table, ResultSet rs) throws SQLException {
         String indexName = rs.getString("INDEX_NAME");
 
         if (indexName == null)
@@ -648,12 +652,12 @@ public class TableService {
      *
      * @throws SQLException
      */
-    private void initPrimaryKeys(Database db, Table table) throws SQLException {
+    private static void initPrimaryKeys(Database db, Table table) throws SQLException {
 
         LOGGER.debug("Querying primary keys for {}", table.getFullName());
         try (ResultSet rs = db.getMetaData().getPrimaryKeys(table.getCatalog(), table.getSchema(), table.getName())){
             while (rs.next())
-                setPrimaryColumn(table, rs);
+                addPrimaryKeyColumn(table, rs);
         } catch (SQLException exc) {
             if (!table.isLogical()) {
                 throw exc;
@@ -665,7 +669,7 @@ public class TableService {
      * @param rs
      * @throws SQLException
      */
-    private void setPrimaryColumn(Table table, ResultSet rs) throws SQLException {
+    private static void addPrimaryKeyColumn(Table table, ResultSet rs) throws SQLException {
         String pkName = rs.getString("PK_NAME");
         if (pkName == null)
             return;
@@ -680,7 +684,7 @@ public class TableService {
         table.setPrimaryColumn(table.getColumn(columnName));
     }
 
-    private void markDownRegistryPage(Table table) {
+    private static void markDownRegistryPage(Table table) {
         String tablePath = "tables/" + table.getName() + ".html";
         Markdown.registryPage(table.getName(), tablePath);
     }

--- a/src/test/java/org/schemaspy/service/TableServiceAddPrimaryKeyColumnTest.java
+++ b/src/test/java/org/schemaspy/service/TableServiceAddPrimaryKeyColumnTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2018 Nils Petzaell
+ *
+ * This file is part of SchemaSpy.
+ *
+ * SchemaSpy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SchemaSpy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with SchemaSpy. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.schemaspy.service;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.schemaspy.cli.CommandLineArguments;
+import org.schemaspy.model.Table;
+import org.schemaspy.model.TableColumn;
+import org.schemaspy.testing.Logger;
+import org.schemaspy.testing.LoggingRule;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Nils Petzaell
+ */
+public class TableServiceAddPrimaryKeyColumnTest {
+
+    @Rule
+    public LoggingRule loggingRule = new LoggingRule();
+
+    private SqlService sqlService = mock(SqlService.class);
+    private CommandLineArguments commandLineArguments = mock(CommandLineArguments.class);
+
+    private TableService tableService = new TableService(sqlService,commandLineArguments);
+
+    private Supplier<Method> addPrimaryKeyColumnMethod = () -> {
+        Method m = null;
+        try {
+            m = TableService.class.getDeclaredMethod("addPrimaryKeyColumn", Table.class, ResultSet.class);
+            m.setAccessible(true);
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        }
+        Method finalM = m;
+        addPrimaryKeyColumnMethod = () -> finalM;
+        return m;
+    };
+
+    private void addPrimaryKeyColumn(Table table, ResultSet rs) throws InvocationTargetException, IllegalAccessException {
+        addPrimaryKeyColumnMethod.get().invoke(tableService, table, rs);
+    }
+
+    @Test
+    public void addExistingTableColumn() throws InvocationTargetException, IllegalAccessException, SQLException {
+        TableColumn tableColumn = mock(TableColumn.class);
+        Table table = mock(Table.class);
+        when(table.getColumn("aColumn")).thenReturn(tableColumn);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getString("PK_NAME")).thenReturn("aPKIndex");
+        when(resultSet.getString("COLUMN_NAME")).thenReturn("aColumn");
+
+        addPrimaryKeyColumn(table, resultSet);
+
+        verify(table, times(1)).setPrimaryColumn(tableColumn);
+    }
+
+    @Test
+    @Logger(TableService.class)
+    public void addNonExistingTableColumn() throws SQLException, InvocationTargetException, IllegalAccessException {
+        Table table = mock(Table.class);
+        when(table.getFullName()).thenReturn("cat.schema.table");
+
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getString("PK_NAME")).thenReturn("aPKNoColumn");
+        when(resultSet.getString("COLUMN_NAME")).thenReturn("NO");
+        when(resultSet.getString("TABLE_CAT")).thenReturn("RE_CAT");
+        when(resultSet.getString("TABLE_SCHEM")).thenReturn("RE_SCHEMA");
+        when(resultSet.getString("TABLE_NAME")).thenReturn("RE_TABLE");
+
+        addPrimaryKeyColumn(table, resultSet);
+
+        verify(table,never()).setPrimaryColumn(any());
+
+        assertThat(loggingRule.getLog()).contains("RE_CAT.RE_SCHEMA.RE_TABLE.NO");
+
+    }
+}

--- a/src/test/java/org/schemaspy/service/TableServiceIsIndexRowTest.java
+++ b/src/test/java/org/schemaspy/service/TableServiceIsIndexRowTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Nils Petzaell
  */
-public class TableServiceTest {
+public class TableServiceIsIndexRowTest {
 
     private SqlService sqlService = mock(SqlService.class);
     private CommandLineArguments commandLineArguments = mock(CommandLineArguments.class);
@@ -46,10 +46,10 @@ public class TableServiceTest {
         Method m = null;
         try {
             m = TableService.class.getDeclaredMethod("isIndexRow", ResultSet.class);
+            m.setAccessible(true);
         } catch (NoSuchMethodException e) {
             e.printStackTrace();
         }
-        m.setAccessible(true);
         Method finalM = m;
         isIndexRowMethod = () -> finalM;
         return m;


### PR DESCRIPTION
This should replace #372 

Instead of having null pointer guards when used, null guard is placed when potentially null would be added to be able to extract as much information as possible in the case of null.