### PR TITLE
Added releases to deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,13 @@ deploy:
     on:
       repo: schemaspy/schemaspy
       all_branches: true
+  - provider: releases
+    api_key: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+    skip_cleanup: true
+    file_glob: true
+    file: target/schemaspy*.jar
+    draft: true
+    on:
+      repo: schemaspy/schemaspy
+      tags: true
+


### PR DESCRIPTION
So when tag is created either locally and pushed or in github.
Travis will build the artifact and upload it to releases as a draft.
This then den be bound to tag that was created.
In short you can create releases with binaries built by travis-ci