### PR TITLE
fixed selectRowCountSql for Oracle DB

### DIFF
--- a/src/main/resources/org/schemaspy/types/ora.properties
+++ b/src/main/resources/org/schemaspy/types/ora.properties
@@ -39,7 +39,7 @@ selectColumnCommentsSql=select table_name, column_name, comments from all_col_co
 # return row_count for a specific :table
 #  many times faster than select count(*)
 #  thanks to Mikheil Kapanadze for the SQL
-selectRowCountSql=select table_rows row_count from information_schema.tables where table_name=:table 
+selectRowCountSql=SELECT NUM_ROWS as row_count FROM ALL_TABLES WHERE TABLE_NAME = :table AND owner = :owner 
 
 # regular expression used in conjunction with -all (and can be command line param '-schemaSpec')
 # this says which schemas to include in our evaluation of "all schemas"


### PR DESCRIPTION
In the ora.properties file the selectRowCountSql is:
`selectRowCountSql=select table_rows row_count from information_schema.tables where table_name=:table`

Unfortunaly Oracle DB does not provide a Information Schema.
The ALL_TABLES metadata work fine for all Oracle DB.