### PR TITLE
added selectRoutinesSql and selectRoutineParametersSql for Oracle DB

### DIFF
--- a/src/main/resources/org/schemaspy/types/ora.properties
+++ b/src/main/resources/org/schemaspy/types/ora.properties
@@ -39,7 +39,13 @@ selectColumnCommentsSql=select table_name, column_name, comments from all_col_co
 # return row_count for a specific :table
 #  many times faster than select count(*)
 #  thanks to Mikheil Kapanadze for the SQL
-selectRowCountSql=SELECT NUM_ROWS as row_count FROM ALL_TABLES WHERE TABLE_NAME = :table AND owner = :owner 
+selectRowCountSql=SELECT NUM_ROWS as row_count FROM ALL_TABLES WHERE TABLE_NAME = :table AND owner = :owner
+
+# select any stored procedures and functions
+selectRoutinesSql=SELECT s.owner || '.' || s.name AS routine_name, s.TYPE AS routine_type, a.DATA_TYPE AS dtd_identifier, 'PL/SQL' AS routine_body, dbms_xmlgen.convert(xmlagg(xmlelement(e,s.text,'').extract('//text()') order by s.line).GetClobVal(), 1) AS routine_definition, null as is_deterministic, null AS sql_data_access, null AS security_type, null AS sql_mode, null AS routine_comment  FROM all_source s LEFT OUTER JOIN all_arguments a ON a.OWNER = s.owner AND a.OBJECT_NAME = s.NAME AND a.DATA_LEVEL = 0 AND a.argument_name IS null where s.owner = :schema GROUP BY s.owner, s.name, s.TYPE, a.data_type
+
+# select parameters for stored procedures and functions
+selectRoutineParametersSql=SELECT nvl2(a.package_name, a.owner || '.' || a.package_name || '.' || a.OBJECT_name, a.owner || '.' || a.OBJECT_name) AS specific_name, a.argument_name AS parameter_name, a.data_type AS dtd_identifier, a.in_out AS parameter_mode FROM all_arguments a WHERE a.OWNER = :schema AND a.argument_name IS NOT null ORDER BY 1, a.position
 
 # regular expression used in conjunction with -all (and can be command line param '-schemaSpec')
 # this says which schemas to include in our evaluation of "all schemas"


### PR DESCRIPTION
this should solve https://github.com/schemaspy/schemaspy/issues/369

As guicampos mentioned - Oracle sometimes is a little special.
Oracle can group functions and procedures in packages. So there are no
"package parameters".

I do not use dba_xxx views and DBMS_METADATA.GET_DDL function - because
you need special rights on the database to use it
(eg SELECT_CATALOG_ROLE).