### PR TITLE
Use included java version, don't update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ jdk:
 addons:
   apt:
     packages:
-      - oracle-java8-installer
       - graphviz
 script:
   - ./travis.sh


### PR DESCRIPTION
There is a oraclejdk8 in the travis image. Don't try to update to latest, just causes pain.
Not with actual java, but with the update procedure.