### PR TITLE
add new parameter relation depth degree 1 or 2 to simplify relation graphs

### DIFF
--- a/docs/source/configuration/commandline.rst
+++ b/docs/source/configuration/commandline.rst
@@ -133,4 +133,5 @@ Diagram related
     Exclude column(s) from diagrams where column(s) aren't directly referenced by focal table, defaults to nothing.
 [-vizjs]
     Use embedded viz.js instead of Graphviz. Useful when graphviz isn't installed. Memory is set to 64 MB, if you receive ther error "Cannot enlarge memory arrays" please report this to us.
-
+[-relationdegreedepth 1 or 2]
+    create relation graph with 1 or 2 depth degree, use 1 degree for database with lot of tables and relations (> 1000)

--- a/docs/source/new.rst
+++ b/docs/source/new.rst
@@ -28,6 +28,7 @@ What's new
 
 * Diagrams
     * Now has option to use embedded viz.js (no need for Graphviz) ``-vizjs``
+    * Choose the relation depth degree 1 or 2 to simplify relation graphs for database with lot of tables and relations
 
 * XML
     * Now includes routines

--- a/src/main/java/org/schemaspy/Config.java
+++ b/src/main/java/org/schemaspy/Config.java
@@ -72,6 +72,7 @@ public final class Config implements HtmlConfig, GraphvizConfig {
 
     private static final int DEFAULT_FONT_SIZE = 11;
     private static final int DEFAULT_TABLE_DETAILS_THRESHOLD = 300;
+    private static final int DEFAULT_RELATION_DEGREE_DEPTH = 2;
 
     private static final Pattern DBTYPE_PATTERN = Pattern.compile(".*org/schemaspy/types/(.*)\\.properties");
 
@@ -122,6 +123,7 @@ public final class Config implements HtmlConfig, GraphvizConfig {
     private String imageFormat;
     private String renderer;
     private Boolean paginationEnabled;
+    private Integer relationDegreeDepth;
     /**      
      * @deprecated replaced by -dp expanding folders
      */
@@ -625,6 +627,33 @@ public final class Config implements HtmlConfig, GraphvizConfig {
         }
 
         return fontSize;
+    }
+    
+    /**
+     * @return
+     * @see #setRelationDegreeDepth(int)
+     */
+    public int getRelationDegreeDepth() {
+        if (relationDegreeDepth == null) {
+            int iRelationDegreeDepth = DEFAULT_RELATION_DEGREE_DEPTH;
+            String param = pullParam("-relationdegreedepth");
+            if (param != null) {
+                try {
+                	iRelationDegreeDepth = Integer.parseInt(param);
+                	if (iRelationDegreeDepth != 1 && iRelationDegreeDepth != 2) {
+                		iRelationDegreeDepth = DEFAULT_RELATION_DEGREE_DEPTH;
+                		LOGGER.warn("relationdegreedepth must be 1 or 2, set default value to 2");
+                	}
+                } catch (NumberFormatException e) {
+                    LOGGER.warn(e.getMessage(), e);
+                    LOGGER.warn("relationdegreedepth must be 1 or 2, set default value to 2");
+                    iRelationDegreeDepth = DEFAULT_RELATION_DEGREE_DEPTH;
+                }
+            }
+            relationDegreeDepth = new Integer(iRelationDegreeDepth);
+        }
+
+        return relationDegreeDepth;
     }
 
     /**
@@ -1509,6 +1538,8 @@ public final class Config implements HtmlConfig, GraphvizConfig {
         params.add(getFont());
         params.add("-fontsize");
         params.add(String.valueOf(getFontSize()));
+        params.add("-relationdegreedepth");
+        params.add(String.valueOf(getRelationDegreeDepth()));
         params.add("-t");
         params.add(getDbType());
         params.add("-imageformat");

--- a/src/main/java/org/schemaspy/SchemaAnalyzer.java
+++ b/src/main/java/org/schemaspy/SchemaAnalyzer.java
@@ -414,7 +414,7 @@ public class SchemaAnalyzer {
         LOGGER.info("Completed summary in {} seconds", duration / SECONDS_IN_MS);
         LOGGER.info("Writing/diagramming details");
         SqlAnalyzer sqlAnalyzer = new SqlAnalyzer(db.getDbmsMeta().getAllKeywords(), db.getTables(), db.getViews());
-        MustacheTableDiagramFactory mustacheTableDiagramFactory = new MustacheTableDiagramFactory(dotProducer, mustacheDiagramFactory, outputDir);
+        MustacheTableDiagramFactory mustacheTableDiagramFactory = new MustacheTableDiagramFactory(dotProducer, mustacheDiagramFactory, outputDir, config.getRelationDegreeDepth());
         HtmlTablePage htmlTablePage = new HtmlTablePage(mustacheCompiler, sqlAnalyzer);
         for (Table table : tables) {
             List<MustacheTableDiagram> mustacheTableDiagrams = mustacheTableDiagramFactory.generateTableDiagrams(table, results.getStats());

--- a/src/test/java/org/schemaspy/output/html/mustache/diagrams/MustacheTableDiagramFactoryTest.java
+++ b/src/test/java/org/schemaspy/output/html/mustache/diagrams/MustacheTableDiagramFactoryTest.java
@@ -85,7 +85,7 @@ public class MustacheTableDiagramFactoryTest {
         when(tableNoRelationships.getMaxChildren()).thenReturn(0);
         when(tableNoRelationships.getMaxParents()).thenReturn(0);
 
-        MustacheTableDiagramFactory mustacheTableDiagramFactory = new MustacheTableDiagramFactory(null, null, temporaryFolder.newFolder("nodiagrams"));
+        MustacheTableDiagramFactory mustacheTableDiagramFactory = new MustacheTableDiagramFactory(null, null, temporaryFolder.newFolder("nodiagrams"), 2);
         List<MustacheTableDiagram> mustacheTableDiagramList = mustacheTableDiagramFactory.generateTableDiagrams(tableNoRelationships, writeStats);
         assertThat(mustacheTableDiagramList).isEmpty();
     }
@@ -104,7 +104,7 @@ public class MustacheTableDiagramFactoryTest {
         MustacheDiagramFactory mustacheDiagramFactory = mock(MustacheDiagramFactory.class);
         when(mustacheDiagramFactory.generateTableDiagram(anyString(),any(File.class),anyString())).thenReturn(new MustacheTableDiagram());
 
-        MustacheTableDiagramFactory mustacheTableDiagramFactory = new MustacheTableDiagramFactory(dotProducer, mustacheDiagramFactory, outputDir);
+        MustacheTableDiagramFactory mustacheTableDiagramFactory = new MustacheTableDiagramFactory(dotProducer, mustacheDiagramFactory, outputDir, 2);
         List<MustacheTableDiagram> mustacheTableDiagramList = mustacheTableDiagramFactory.generateTableDiagrams(table, writeStats);
         assertThat(mustacheTableDiagramList.size()).isEqualTo(1);
         assertThat(mustacheTableDiagramList.get(0).getActive()).isNotEmpty();
@@ -124,7 +124,7 @@ public class MustacheTableDiagramFactoryTest {
         MustacheDiagramFactory mustacheDiagramFactory = mock(MustacheDiagramFactory.class);
         when(mustacheDiagramFactory.generateTableDiagram(anyString(),any(File.class),anyString())).then(invocation -> new MustacheTableDiagram());
 
-        MustacheTableDiagramFactory mustacheTableDiagramFactory = new MustacheTableDiagramFactory(dotProducer, mustacheDiagramFactory, outputDir);
+        MustacheTableDiagramFactory mustacheTableDiagramFactory = new MustacheTableDiagramFactory(dotProducer, mustacheDiagramFactory, outputDir, 2);
         List<MustacheTableDiagram> mustacheTableDiagramList = mustacheTableDiagramFactory.generateTableDiagrams(table, writeStats);
         assertThat(mustacheTableDiagramList.size()).isEqualTo(2);
         assertThat(mustacheTableDiagramList.get(0).getActive()).isNotEmpty();
@@ -155,7 +155,7 @@ public class MustacheTableDiagramFactoryTest {
         MustacheDiagramFactory mustacheDiagramFactory = mock(MustacheDiagramFactory.class);
         when(mustacheDiagramFactory.generateTableDiagram(anyString(),any(File.class),anyString())).then(invocation -> new MustacheTableDiagram());
 
-        MustacheTableDiagramFactory mustacheTableDiagramFactory = new MustacheTableDiagramFactory(dotProducer, mustacheDiagramFactory, outputDir);
+        MustacheTableDiagramFactory mustacheTableDiagramFactory = new MustacheTableDiagramFactory(dotProducer, mustacheDiagramFactory, outputDir, 2);
         List<MustacheTableDiagram> mustacheTableDiagramList = mustacheTableDiagramFactory.generateTableDiagrams(table, writeStats);
         assertThat(mustacheTableDiagramList.size()).isEqualTo(3);
         assertThat(mustacheTableDiagramList.get(0).getActive()).isNotEmpty();
@@ -188,7 +188,7 @@ public class MustacheTableDiagramFactoryTest {
         MustacheDiagramFactory mustacheDiagramFactory = mock(MustacheDiagramFactory.class);
         when(mustacheDiagramFactory.generateTableDiagram(anyString(),any(File.class),anyString())).then(invocation -> new MustacheTableDiagram());
 
-        MustacheTableDiagramFactory mustacheTableDiagramFactory = new MustacheTableDiagramFactory(dotProducer, mustacheDiagramFactory, outputDir);
+        MustacheTableDiagramFactory mustacheTableDiagramFactory = new MustacheTableDiagramFactory(dotProducer, mustacheDiagramFactory, outputDir, 2);
         List<MustacheTableDiagram> mustacheTableDiagramList = mustacheTableDiagramFactory.generateTableDiagrams(table, writeStats);
         assertThat(mustacheTableDiagramList.size()).isEqualTo(4);
         assertThat(mustacheTableDiagramList.get(0).getActive()).isNotEmpty();


### PR DESCRIPTION
I got some troubles with very big database (more than 3000 tables).
The output result is bigger > 4GB. The main cause is the 2sd degree relation graphs, some of graphs are > 11MB.
I add a new parameter relationdegreedepth,
You could choose the relation depth degree 1 or 2 (default value 2) to simplify relation graphs for database with lot of tables and relations.
The 1 value is best for big database with more than 1000 tables.