### PR TITLE
Bumped spring boot to version 2.1.2.RELEASE to avoid reflection warn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <sonar.junit.reportPaths>target/surefire-reports,target/failsafe-reports</sonar.junit.reportPaths>
 
-        <spring-boot.version>1.5.9.RELEASE</spring-boot.version>
+        <spring-boot.version>2.1.2.RELEASE</spring-boot.version>
         <testcontainers-java.version>1.10.1</testcontainers-java.version>
         <testcontainers-junit.version>${testcontainers-java.version}.0.0</testcontainers-junit.version>
 

--- a/src/main/java/org/schemaspy/logging/StackTraceOmitter.java
+++ b/src/main/java/org/schemaspy/logging/StackTraceOmitter.java
@@ -51,8 +51,8 @@ public class StackTraceOmitter extends ThrowableProxyConverter implements Applic
     public String convert(ILoggingEvent event) {
         if (SCHEMA_SPY_LOGGER.isDebugEnabled())
             return super.convert(event);
-        omittedStackTrace.set(true);
         if (Objects.nonNull(event.getThrowableProxy())) {
+            omittedStackTrace.set(true);
             return event.getThrowableProxy().getMessage() + CoreConstants.LINE_SEPARATOR;
         }
         return CoreConstants.EMPTY_STRING;


### PR DESCRIPTION
* fixes #506
* fixed possible defect or issue after dump related to stacktrace and
  `-debug` advice