### PR TITLE
Initial support for DB2 for i (former AS/400)

### DIFF
--- a/src/main/resources/org/schemaspy/types/db2i.properties
+++ b/src/main/resources/org/schemaspy/types/db2i.properties
@@ -1,0 +1,11 @@
+description=IBM DB2 for i (former as400) driver
+
+driver=com.ibm.as400.access.AS400JDBCDriver
+connectionSpec=jdbc:as400://<hostOptionalPort>/<db>
+host=database host
+port=port on database host
+db=database SID as known on host
+selectSchemasSql= select schema_text as schema_comment from qsys2.sysschemas where schema_name = :schema
+selectTableCommentsSql=select table_name, table_text as comments from qsys2.systables where table_schema = :schema
+selectColumnCommentsSql=select table_name, column_name, column_text as comments from qsys2.syscolumns2 where table_schema = :schema
+selectViewSql=select view_definition from QSYS2.VIEWS where table_schema = :schema and table_name = :view


### PR DESCRIPTION
Hi,
I ran schemaspy-6.0.0 successfully on a DB2 for i V7R3m0 with the JDBC driver jtopen-9.8.
This is the configuration file.