### PR TITLE
commandline.rst updated - argument doesnt exist

### DIFF
--- a/docs/source/configuration/commandline.rst
+++ b/docs/source/configuration/commandline.rst
@@ -61,7 +61,6 @@ Processing
     Filter using a specific catalog this is usually the root of the database and contains schemas.
 [-s schema]
     Database schema. This is optional if it's the same as user or isn't supported by your database.
-    Use -noschema if your database thinks it supports schemas but doesn't (e.g. older versions of Informix).
 [-schemas listOfSchemas]
     List of schemas to analyze, separated by space or ``,`` or ``'`` or ``"``
 [-all]


### PR DESCRIPTION
I am working with informix servers and tried to implement the '-noschema' argument but the Tag is not even used in Code so it always gives the same Error. In the Documentation I wanted to remove the sentence referring to '-noschema' argument. The same in 6.0.0 Documentation.

I hope we can improve the documentation alot more, because it would make my life much easier :)