### PR TITLE
additional comment to connect with MS SQL Server

### DIFF
--- a/docs/source/started.rst
+++ b/docs/source/started.rst
@@ -12,6 +12,7 @@ To use an alternative configuration file run SchemaSpy with parameter: ``java -j
 Config file example: ::
 
 	# type of database. Run with -dbhelp for details
+	# if mssql doesn't work: try mssql08 in combination with sqljdbc_7.2, this combination has been tested
 	schemaspy.t=mssql
 	# optional path to alternative jdbc drivers. 
 	schemaspy.dp=path/to/drivers


### PR DESCRIPTION
It was hard to find a working combination to connect with MS SQL Server, I added this in a comment line to make the "Get Started" easier on Microsoft SQL Server.
Another idea would be an extra page with several tested combinations of drivers.