### PR TITLE
Update the Install Requirements, adding JDBC driver

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,7 +11,7 @@ Before you can use SchemaSpy you must have the following requirements available 
 * viz.js or Graphviz
 
 Java
-^^^^^^
+^^^^
 
 You will need to have a supported version of Java installed, which includes:
 
@@ -24,7 +24,8 @@ If you don't already have a proper version of Java installed, see `OpenJDK <http
 
 
 JDBC Driver
-^^^^^^
+^^^^^^^^^^^
+
 No JDBC drivers are included with the jar-distribution of SchemaSpy.
 
 In some case, a JDBC driver may already exist on your local system if your database happens to come with drivers. Otherwise, you will need to download one yourself.
@@ -53,15 +54,15 @@ You will need to tell SchemaSpy where to find the JDBC driver you require. For e
 
 If your JDBC .jar file is in a different directory, then the -dp parameter would need to specify the directory path to the file, like ``-dp /opt/some-directory/your-jdbc-driver-name.jar``. 
 
-See :ref:`_commandline` for more information and advanced cases, such if you need to load multiple driver files with ``-loadjars``.
+See :ref:`commandline` for more information and advanced situations.
 
 viz.js or Graphviz
-^^^^^^^^
+^^^^^^^^^^^^^^^^^^
 This is necessary to render graphical representations / images of the database relationships.
 
 SchemaSpy version 6.1.0 and higher now comes with viz.js, so you will not need to download anything unless you're using SchemaSpy version 6.0 or lower.
 
-For SchemaSpy version 6.1.0 or higher, simply include the ``-vizjs``  :ref:`_commandline` when executing the SchemaSpy command.
+For SchemaSpy version 6.1.0 or higher, simply include ``-vizjs`` as a command line argument when executing the SchemaSpy command.
 
 If you must use Schemaspy version 6.0 or less, then Graphviz will need to be installed as follows.
 
@@ -79,7 +80,7 @@ If you must use Schemaspy version 6.0 or less, then Graphviz will need to be ins
     Please read carefully the detailed instructions on how to `install Graphviz on your operating system <http://www.graphviz.org/download/>`_.
 
 SchemaSpy
-----------
+---------
 
 SchemaSpy is just a single executable jar-file (schemaspy-[version].jar), you can `download releases from the SchemaSpy website <http://schemaspy.org>`_ or the `GitHub releases page <https://github.com/schemaspy/schemaspy/releases>`_.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,20 +4,66 @@ Installation
 Requirements
 ------------
 
-Before you can start using SchemaSpy you must have installed two things in your system environment.
+Before you can use SchemaSpy you must have the following requirements available on your local system.
 
-Java 8
+* Java
+* a JDBC driver file for your specific database engine 
+* viz.js or Graphviz
+
+Java
 ^^^^^^
 
-Download instructions for all operating systems: `https://java.com/en/download/manual.jsp <https://java.com/en/download/manual.jsp>`_
+You will need to have a supported version of Java installed, which includes:
 
-Optional
---------
+* Java version 8 or higher
+* OR OpenJDK 1.8 or higher - an open-source alternative
 
-Since version 6.1.0 Graphviz is no longer required. There is an embedded viz.js that can be used by adding command line argument ``vizjs``
+You can run ``java -version`` in a terminal to check the version of any currently installed Java.
 
-Graphviz
+If you don't already have a proper version of Java installed, see `OpenJDK <https://openjdk.java.net/install/>`_ or `Oracle Java <https://www.oracle.com/java/technologies/javase-downloads.html>`_ for download and install instructions for your operating systems.
+
+
+JDBC Driver
+^^^^^^
+No JDBC drivers are included with the jar-distribution of SchemaSpy.
+
+In some case, a JDBC driver may already exist on your local system if your database happens to come with drivers. Otherwise, you will need to download one yourself.
+
+If downloading a driver, you can usually find an approriate driver by searching the internet for "[name of your database] JDBC driver".
+
+Verify the driver you download is compatible with the version of database management system / engine that you are using. For instance, if you're using PostgreSQL 13 the JDBC driver will need to support PostgreSQL 13.
+
+Here is a list of where you might find drivers for common database management systems:
+
+* `DB2 <https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads>`_
+* `Firebird <https://firebirdsql.org/en/jdbc-driver/>`_
+* `Impala <https://impala.apache.org/docs/build/html/topics/impala_jdbc.html>`_
+* `MySQL <https://www.mysql.com/products/connector/>`_
+* `MariaDB <https://downloads.mariadb.org/connector-java/>`_
+* `Netezza <https://www.ibm.com/support/knowledgecenter/SSULQD_7.2.1/com.ibm.nz.datacon.doc/c_datacon_installing_configuring_jdbc.html>`_
+* `Oracle <https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html>`_
+* `PostgreSQL <https://jdbc.postgresql.org/download.html>`_
+* `Redshift <https://docs.aws.amazon.com/redshift/latest/mgmt/configuring-connections.html>`_
+* `SQLite <https://github.com/xerial/sqlite-jdbc>`_
+* `SQL Server <https://docs.microsoft.com/en-us/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server>`_
+* `Sybase <http://infocenter.sybase.com/help/index.jsp?topic=/com.sybase.help.sqlanywhere.12.0.1/dbprogramming/jconnect-using-jdbxextra.html>`_
+* `Teradata <https://downloads.teradata.com/download/connectivity/jdbc-driver>`_
+
+You will need to tell SchemaSpy where to find the JDBC driver you require. For example, if you downloaded the Postgres JDBC file called postgresql-42.2.19.jar to the current directory the command would include the -dp parameter, like ``-dp postgresql-42.2.19.jar``. 
+
+If your JDBC .jar file is in a different directory, then the -dp parameter would need to specify the directory path to the file, like ``-dp /opt/some-directory/your-jdbc-driver-name.jar``. 
+
+See :ref:`_commandline` for more information and advanced cases, such if you need to load multiple driver files with ``-loadjars``.
+
+viz.js or Graphviz
 ^^^^^^^^
+This is necessary to render graphical representations / images of the database relationships.
+
+SchemaSpy version 6.1.0 and higher now comes with viz.js, so you will not need to download anything unless you're using SchemaSpy version 6.0 or lower.
+
+For SchemaSpy version 6.1.0 or higher, simply include the ``-vizjs``  :ref:`_commandline` when executing the SchemaSpy command.
+
+If you must use Schemaspy version 6.0 or less, then Graphviz will need to be installed as follows.
 
 - Windows
     The easiest way to install Graphviz is to download the msi package from `http://www.graphviz.org/download/ <http://www.graphviz.org/download/>`_
@@ -30,12 +76,12 @@ Graphviz
             C:\Program Files (x86)\Graphviz2.38\bin        
 
 - Linux, Mac OS
-    Please read carefully the detailed instructions on how to install Graphviz on your os version `http://www.graphviz.org/download/ <http://www.graphviz.org/download/>`_.
+    Please read carefully the detailed instructions on how to `install Graphviz on your operating system <http://www.graphviz.org/download/>`_.
 
 SchemaSpy
 ----------
 
-SchemaSpy is just a single executable jar-file (schemaspy-[version].jar), you can download releases from http://schemaspy.org or the github releases page https://github.com/schemaspy/schemaspy/releases
+SchemaSpy is just a single executable jar-file (schemaspy-[version].jar), you can `download releases from the SchemaSpy website <http://schemaspy.org>`_ or the `GitHub releases page <https://github.com/schemaspy/schemaspy/releases>`_.
 
 If you feel adventurous there is a link in the README.md for latest builds.
 


### PR DESCRIPTION
Here's a first crack at adding the JDBC driver requirement to the documentation and updating the requirements section.

I don't know if you officially support OpenJDK, but I added that as an option since it's working on my system.

Also, I tried to run `make make.bat` and `sphinx-build`, but they failed.  I saw a note in one of the other issues that Readthedocs probably does the compile step. I did include a few internal :ref links, but I can't really test them without something compiling the files.

Closes #747 

- Add a list of links to likely JDBC download locations for most of the supported engines
- Converted external links to text links
- Updated the Java section to include OpenJDK as an option
- Rework the viz.js or Graphviz requirement section