### PR TITLE
Approximate row count for postgres

### DIFF
--- a/src/main/resources/org/schemaspy/types/pgsql.properties
+++ b/src/main/resources/org/schemaspy/types/pgsql.properties
@@ -52,3 +52,5 @@ order by p.specific_name, p.ordinal_position
 selectCheckConstraintsSql=select tc.table_name, tc.constraint_name, cc.check_clause as text from information_schema.check_constraints cc left join information_schema.table_constraints tc on tc.constraint_catalog = cc.constraint_catalog and tc.constraint_schema = cc.constraint_schema and tc.constraint_name = cc.constraint_name where cc.constraint_name not like '%not_null' and tc.constraint_schema = :schema
 
 selectSequencesSql=SELECT seqs.sequence_name, seqs.start_value, seqs.increment FROM information_schema.sequences seqs WHERE seqs.sequence_schema = :schema
+
+selectRowCountSql=SELECT reltuples AS row_count from pg_class WHERE oid = CAST(:schema || '.' || :table AS regclass)


### PR DESCRIPTION
As mentioned [here](https://wiki.postgresql.org/wiki/Slow_Counting), row count can be extremely slow for postgres with large tables.
This introduces custom SQL as recommended [here](https://wiki.postgresql.org/wiki/Count_estimate) for postgres instead of `count(*)` to get approximate row counts instead of hanging indefinitely for huge tables