### PR TITLE
Expand rails-specific relationship detection

### DIFF
--- a/src/main/java/org/schemaspy/DbAnalyzer.java
+++ b/src/main/java/org/schemaspy/DbAnalyzer.java
@@ -155,12 +155,43 @@ public class DbAnalyzer {
         for (Table table : tables.values()) {
             for (TableColumn column : table.getColumns()) {
                 String columnName = column.getName().toLowerCase();
-                if (!column.isForeignKey() && column.allowsImpliedParents() && columnName.endsWith("_id")) {
-                    String singular = columnName.substring(0, columnName.length() - "_id".length());
-                    String primaryTableName = Inflection.pluralize(singular);
+                if (!column.isForeignKey() && column.allowsImpliedParents() && (columnName.endsWith("_id") || columnName.endsWith("_uuid"))) {
+                    String suffix = "";
+                    if (columnName.endsWith("_id")) {
+                        suffix = "_id";
+                    } else {
+                        suffix = "_uuid";
+                    }
+                    String tableName = columnName.substring(0, columnName.length() - suffix.length());
+                    String primaryTableName = Inflection.pluralize(tableName);
                     Table primaryTable = tables.get(primaryTableName);
+
+                    /*
+                     * If the column name doesn't match a table name, it's likely that the column name has a non-default
+                     * name. This often happens when a table has multiple columns that join different rows in the same
+                     * parent table, e.g. "previous_company_id" and "current_company_id".
+                     * To still connect non-default relationships rows, remove parts of the name until the first "_"
+                     * and see if it matches a table now. If not, keep removing from the column name until the name
+                     * is empty or a table was matched. Example:
+                     * "previous_company_id" -> "company_id" => match!
+                     * "alternative_mailing_address_id" -> "mailing_address_id" -> "address_id" => match!
+                     * "3rd_party_system_id" -> "party_system_id" -> "system_id" -> no match!
+                     */
+                    if (primaryTable == null) {
+                        List<String> parts = new LinkedList<>(Arrays.asList(tableName.split("_")));
+                        while (primaryTable == null && !parts.isEmpty()) {
+                            parts.remove(0);
+                            primaryTable = tables.get(Inflection.pluralize(String.join("_", parts)));
+                        }
+                    }
+
                     if (primaryTable != null) {
-                        TableColumn primaryColumn = primaryTable.getColumn("ID");
+                        TableColumn primaryColumn = null;
+                        if (suffix == "_id") {
+                            primaryColumn = primaryTable.getColumn("ID");
+                        } else {
+                            primaryColumn = primaryTable.getColumn("UUID");
+                        }
                         if (primaryColumn != null) {
                             railsConstraints.add(new RailsForeignKeyConstraint(primaryColumn, column));
                         }


### PR DESCRIPTION
I'm not sure if this functionality is of interest to anyone else, but I figured I can share it here and close the PR if it's not something that should be merged. I'm also happy to add some changes if requested/useful.

## What
Expand the relation detection for rails naming schemes by supporting custom column names and adding support for UUIDs.

## Why

Ruby on Rails doesn't add foreign keys by default, instead relying on a specific naming scheme, which the -rails flag activates. In this scheme, table names are plural and each table has an `id` column. Child-tables reference the parent-table via `"${singularParentTableName}.id"`, e.g. a table called `companies` would be referenced as `company_id`.

It's possible to use custom names for mapping columns in rails, often used to map two columns to two different records in the same parent table. This PR adds support for prefixed column names, e.g. `original_company_id` and `current_company_id` would both resolve to `companies.id`.

We also use UUIDs in some areas in addition to an autoincrementing ID field, and this PR adds support for `_uuid` suffices.