### PR TITLE
fix(vizjs): write svg as utf-8

### DIFF
--- a/src/main/java/org/schemaspy/output/diagram/vizjs/VizJSDot.java
+++ b/src/main/java/org/schemaspy/output/diagram/vizjs/VizJSDot.java
@@ -21,14 +21,15 @@ package org.schemaspy.output.diagram.vizjs;
 import org.apache.commons.io.IOUtils;
 import org.schemaspy.output.diagram.DiagramException;
 import org.schemaspy.output.diagram.DiagramProducer;
+import org.schemaspy.util.Writers;
 
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.InputStream;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 
 public class VizJSDot implements DiagramProducer {
@@ -65,7 +66,7 @@ public class VizJSDot implements DiagramProducer {
         try {
             String dotSource = IOUtils.toString(dotFile.toURI().toURL(), StandardCharsets.UTF_8);
             String svg = toSvg(dotSource, MB_64);
-            try (FileWriter diagramWriter = new FileWriter(diagramFile)){
+            try (Writer diagramWriter = Writers.newBufferedWriter(diagramFile)){
                 IOUtils.write(svg, diagramWriter);
             }
             return "";

--- a/src/main/java/org/schemaspy/util/Writers.java
+++ b/src/main/java/org/schemaspy/util/Writers.java
@@ -18,6 +18,7 @@
  */
 package org.schemaspy.util;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -31,6 +32,10 @@ public class Writers {
 
     public static PrintWriter newPrintWriter(File file) throws IOException {
         return new PrintWriter(Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8, StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING));
+    }
+
+    public static BufferedWriter newBufferedWriter(File file) throws IOException {
+        return Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8, StandardOpenOption.WRITE, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
     }
 
 }


### PR DESCRIPTION
SVG should be UTF-8, but was written with system default encoding.

fixes #797 
fixes #669 