### PR TITLE
Dockerfile: openjdk:17-alpine3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u111-jre-alpine
+FROM openjdk:17-alpine3.14
 
 ENV LC_ALL=C
 


### PR DESCRIPTION
Closes https://github.com/schemaspy/schemaspy/issues/849 by upgrading the Dockerfile to Java 17 (i.e. `openjdk:17-alpine3.14`).