### PR TITLE
chore: link library for dot

### DIFF
--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/AddTableNodeLinkFactory.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/AddTableNodeLinkFactory.java
@@ -1,0 +1,21 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.schemaspy.model.Table;
+
+public class AddTableNodeLinkFactory implements TableNodeLinkFactory{
+
+    private final boolean multiSchema;
+    private final TableNodeLinkFactory tableNodeLinkFactory;
+
+    public AddTableNodeLinkFactory(boolean multiSchema, TableNodeLinkFactory tableNodeLinkFactory) {
+        this.multiSchema = multiSchema;
+        this.tableNodeLinkFactory = tableNodeLinkFactory;
+    }
+    @Override
+    public NodeLink nodeLink(Table table) {
+        if (!table.isRemote() || multiSchema) {
+            return tableNodeLinkFactory.nodeLink(table);
+        }
+        return new NoNodeLink();
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/AddTableNodeLinkFactoryBuilder.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/AddTableNodeLinkFactoryBuilder.java
@@ -1,0 +1,13 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+public class AddTableNodeLinkFactoryBuilder {
+    private final boolean multiSchema;
+
+    public AddTableNodeLinkFactoryBuilder(boolean multiSchema) {
+        this.multiSchema = multiSchema;
+    }
+
+    public TableNodeLinkFactory withTableNodeLinkFactory(TableNodeLinkFactory tableNodeLinkFactory) {
+        return new AddTableNodeLinkFactory(multiSchema, tableNodeLinkFactory);
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/FromBase.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/FromBase.java
@@ -1,0 +1,14 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+public class FromBase implements NodeLink {
+
+    private final NodeLink nodeLink;
+    public FromBase(NodeLink nodeLink) {
+        this.nodeLink = nodeLink;
+    }
+
+    @Override
+    public String asString() {
+        return "tables/" + nodeLink.asString();
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/FromBaseTableNodeLinkFactory.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/FromBaseTableNodeLinkFactory.java
@@ -1,0 +1,14 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.schemaspy.model.Table;
+
+public class FromBaseTableNodeLinkFactory implements TableNodeLinkFactory {
+
+    @Override
+    public NodeLink nodeLink(Table table) {
+        if (table.isRemote()) {
+            return new RemoteFromBase(table, new HtmlWithEncodedName(table));
+        }
+        return new FromBase(new HtmlWithEncodedName(table));
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/HtmlWithEncodedName.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/HtmlWithEncodedName.java
@@ -1,0 +1,18 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.schemaspy.model.Table;
+import org.schemaspy.view.FileNameGenerator;
+
+public class HtmlWithEncodedName implements NodeLink {
+
+    private final Table table;
+    public HtmlWithEncodedName(Table table) {
+        this.table = table;
+    }
+
+    @Override
+    public String asString() {
+        return new FileNameGenerator().generate(table.getName()) + ".html";
+    }
+
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/NoNodeLink.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/NoNodeLink.java
@@ -1,0 +1,8 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+public class NoNodeLink implements NodeLink {
+    @Override
+    public String asString() {
+        return "";
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/NodeLink.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/NodeLink.java
@@ -1,0 +1,8 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+public interface NodeLink {
+
+    @SuppressWarnings("squid:S1075") //not a uri
+    String TABLES_PATH = "/tables/";
+    String asString();
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/Relative.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/Relative.java
@@ -1,0 +1,14 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+public class Relative implements NodeLink {
+
+    private final NodeLink nodeLink;
+    public Relative(NodeLink nodeLink) {
+        this.nodeLink = nodeLink;
+    }
+
+    @Override
+    public String asString() {
+        return nodeLink.asString();
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/RelativeTableNodeLinkFactory.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/RelativeTableNodeLinkFactory.java
@@ -1,0 +1,14 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.schemaspy.model.Table;
+
+public class RelativeTableNodeLinkFactory implements TableNodeLinkFactory {
+
+    @Override
+    public NodeLink nodeLink(Table table) {
+        if (table.isRemote()) {
+            return new RemoteRelative(table, new HtmlWithEncodedName(table));
+        }
+        return new Relative(new HtmlWithEncodedName(table));
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/RelativeToDiagram.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/RelativeToDiagram.java
@@ -1,0 +1,14 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+public class RelativeToDiagram implements NodeLink {
+
+    private final NodeLink nodeLink;
+    public RelativeToDiagram(NodeLink nodeLink) {
+        this.nodeLink = nodeLink;
+    }
+
+    @Override
+    public String asString() {
+        return "../.." + TABLES_PATH + nodeLink.asString();
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/RelativeToDiagramTableNodeLinkFactory.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/RelativeToDiagramTableNodeLinkFactory.java
@@ -1,0 +1,26 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.schemaspy.model.Table;
+import org.schemaspy.output.diagram.DiagramFactory;
+
+public class RelativeToDiagramTableNodeLinkFactory implements TableNodeLinkFactory{
+
+    private final DiagramFactory diagramFactory;
+    private final TableNodeLinkFactory tableNodeLinkFactory;
+
+    public RelativeToDiagramTableNodeLinkFactory(DiagramFactory diagramFactory, TableNodeLinkFactory tableNodeLinkFactory) {
+        this.diagramFactory = diagramFactory;
+        this.tableNodeLinkFactory = tableNodeLinkFactory;
+    }
+
+    @Override
+    public NodeLink nodeLink(Table table) {
+        if ("svg".equalsIgnoreCase(diagramFactory.getDiagramFormat())) {
+            if(table.isRemote()) {
+                return new RemoteRelativeToDiagram(table, new HtmlWithEncodedName(table));
+            }
+            return new RelativeToDiagram(new HtmlWithEncodedName(table));
+        }
+        return tableNodeLinkFactory.nodeLink(table);
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/RelativeToDiagramTableNodeLinkFactoryBuilder.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/RelativeToDiagramTableNodeLinkFactoryBuilder.java
@@ -1,0 +1,15 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.schemaspy.output.diagram.DiagramFactory;
+
+public class RelativeToDiagramTableNodeLinkFactoryBuilder {
+    private final DiagramFactory diagramFactory;
+
+    public RelativeToDiagramTableNodeLinkFactoryBuilder(DiagramFactory diagramFactory) {
+        this.diagramFactory = diagramFactory;
+    }
+
+    public TableNodeLinkFactory withTableNodeLinkFactory(TableNodeLinkFactory tableNodeLinkFactory) {
+        return new RelativeToDiagramTableNodeLinkFactory(diagramFactory, tableNodeLinkFactory);
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/RemoteFromBase.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/RemoteFromBase.java
@@ -1,0 +1,18 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.schemaspy.model.Table;
+import org.schemaspy.view.FileNameGenerator;
+
+public class RemoteFromBase implements NodeLink {
+
+    private final Table table;
+    private final NodeLink nodeLink;
+    public RemoteFromBase(Table table, NodeLink nodeLink) {
+        this.table = table;
+        this.nodeLink = nodeLink;
+    }
+    @Override
+    public String asString() {
+        return "../" + new FileNameGenerator().generate(table.getContainer()) + TABLES_PATH + nodeLink.asString();
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/RemoteRelative.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/RemoteRelative.java
@@ -1,0 +1,19 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.schemaspy.model.Table;
+import org.schemaspy.view.FileNameGenerator;
+
+public class RemoteRelative implements NodeLink {
+
+    private final Table table;
+    private final NodeLink nodeLink;
+    public RemoteRelative(Table table, NodeLink nodeLink) {
+        this.table = table;
+        this.nodeLink = nodeLink;
+    }
+
+    @Override
+    public String asString() {
+        return "../../" + new FileNameGenerator().generate(table.getContainer()) + TABLES_PATH + nodeLink.asString();
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/RemoteRelativeToDiagram.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/RemoteRelativeToDiagram.java
@@ -1,0 +1,19 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.schemaspy.model.Table;
+import org.schemaspy.view.FileNameGenerator;
+
+public class RemoteRelativeToDiagram implements NodeLink {
+
+    private final Table table;
+    private final NodeLink nodeLink;
+    public RemoteRelativeToDiagram(Table table, NodeLink nodeLink) {
+        this.table = table;
+        this.nodeLink = nodeLink;
+    }
+
+    @Override
+    public String asString() {
+        return "../../../" + new FileNameGenerator().generate(table.getContainer()) + TABLES_PATH + nodeLink.asString();
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/TableNodeLinkFactory.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/TableNodeLinkFactory.java
@@ -1,0 +1,8 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.schemaspy.model.Table;
+
+public interface TableNodeLinkFactory {
+
+    NodeLink nodeLink(Table table);
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/WithTargetTop.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/WithTargetTop.java
@@ -1,0 +1,16 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+public class WithTargetTop implements NodeLink {
+    private final NodeLink nodeLink;
+    public WithTargetTop(NodeLink nodeLink) {
+        this.nodeLink = nodeLink;
+    }
+
+    @Override
+    public String asString() {
+        return "    URL=\"" +nodeLink.asString()  + "\"" +
+                System.lineSeparator() +
+                "    target=\"_top\"" +
+                System.lineSeparator();
+    }
+}

--- a/src/main/java/org/schemaspy/output/dot/schemaspy/link/WithTargetTopTableNodeLinkFactory.java
+++ b/src/main/java/org/schemaspy/output/dot/schemaspy/link/WithTargetTopTableNodeLinkFactory.java
@@ -1,0 +1,17 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.schemaspy.model.Table;
+
+public class WithTargetTopTableNodeLinkFactory implements TableNodeLinkFactory {
+
+    private final TableNodeLinkFactory tableNodeLinkFactory;
+
+    public WithTargetTopTableNodeLinkFactory(TableNodeLinkFactory tableNodeLinkFactory) {
+        this.tableNodeLinkFactory = tableNodeLinkFactory;
+    }
+
+    @Override
+    public NodeLink nodeLink(Table table) {
+        return new WithTargetTop(tableNodeLinkFactory.nodeLink(table));
+    }
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/AddTableNodeLinkFactoryBuilderTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/AddTableNodeLinkFactoryBuilderTest.java
@@ -1,0 +1,13 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AddTableNodeLinkFactoryBuilderTest {
+
+    @Test
+    void wrapReturnsATableNodeLinkFactory() {
+        assertThat(new AddTableNodeLinkFactoryBuilder(true).withTableNodeLinkFactory((t) -> () -> "yepp")).isInstanceOf(TableNodeLinkFactory.class);
+    }
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/AddTableNodeLinkFactoryTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/AddTableNodeLinkFactoryTest.java
@@ -1,0 +1,33 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+import org.schemaspy.model.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AddTableNodeLinkFactoryTest {
+
+    @Test
+    void returnDelegateIfMultiSchema() {
+        Table table = mock(Table.class);
+        when(table.isRemote()).thenReturn(true);
+        assertThat(new AddTableNodeLinkFactory(true, (t) -> () -> "yepp").nodeLink(table).asString()).contains("yepp");
+    }
+
+    @Test
+    void returnDelegateIfNotRemote() {
+        Table table = mock(Table.class);
+        when(table.isRemote()).thenReturn(false);
+        assertThat(new AddTableNodeLinkFactory(false, (t) -> () -> "yepp").nodeLink(table).asString()).contains("yepp");
+    }
+
+    @Test
+    void returnNoNodeLinkIfRemoteAndSingleSchema() {
+        Table table = mock(Table.class);
+        when(table.isRemote()).thenReturn(true);
+        assertThat(new AddTableNodeLinkFactory(false, (t) -> () -> "yepp").nodeLink(table)).isInstanceOf(NoNodeLink.class);
+    }
+
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/FromBaseTableNodeLinkFactoryTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/FromBaseTableNodeLinkFactoryTest.java
@@ -1,0 +1,28 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+import org.schemaspy.model.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FromBaseTableNodeLinkFactoryTest {
+
+    @Test
+    void remoteTable() {
+        Table table = mock(Table.class);
+        when(table.isRemote()).thenReturn(true);
+        when(table.getName()).thenReturn("remoteTable");
+        when(table.getContainer()).thenReturn("schema");
+        assertThat(new FromBaseTableNodeLinkFactory().nodeLink(table).asString()).isEqualTo("../schema/tables/remoteTable.html");
+    }
+
+    @Test
+    void localTable() {
+        Table table = mock(Table.class);
+        when(table.isRemote()).thenReturn(false);
+        when(table.getName()).thenReturn("localTable");
+        assertThat(new FromBaseTableNodeLinkFactory().nodeLink(table).asString()).isEqualTo("tables/localTable.html");
+    }
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/FromBaseTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/FromBaseTest.java
@@ -1,0 +1,13 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FromBaseTest {
+
+    @Test
+    void pathIsFromBase() {
+        assertThat(new FromBase(() -> "tableA.html").asString()).contains("tables/tableA.html");
+    }
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/HtmlWithEncodedNameTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/HtmlWithEncodedNameTest.java
@@ -1,0 +1,19 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+import org.schemaspy.model.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class HtmlWithEncodedNameTest {
+
+    @Test
+    void replacesSpacesWithPercentage20() {
+        Table table = mock(Table.class);
+        when(table.getName()).thenReturn("table A");
+        assertThat(new HtmlWithEncodedName(table).asString()).isEqualTo("table_A_a370846f.html");
+    }
+
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/NoNodeLinkTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/NoNodeLinkTest.java
@@ -1,0 +1,13 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoNodeLinkTest {
+
+    @Test
+    void shouldAlwaysBeEmpty() {
+        assertThat(new NoNodeLink().asString()).isEmpty();
+    }
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/RelativeTableNodeLinkFactoryTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/RelativeTableNodeLinkFactoryTest.java
@@ -1,0 +1,28 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+import org.schemaspy.model.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RelativeTableNodeLinkFactoryTest {
+    @Test
+    void remoteTable() {
+        Table table = mock(Table.class);
+        when(table.isRemote()).thenReturn(true);
+        when(table.getName()).thenReturn("remoteTable");
+        when(table.getContainer()).thenReturn("schema");
+        assertThat(new RelativeTableNodeLinkFactory().nodeLink(table).asString()).isEqualTo("../../schema/tables/remoteTable.html");
+    }
+
+    @Test
+    void localTable() {
+        Table table = mock(Table.class);
+        when(table.isRemote()).thenReturn(false);
+        when(table.getName()).thenReturn("localTable");
+        assertThat(new RelativeTableNodeLinkFactory().nodeLink(table).asString()).isEqualTo("localTable.html");
+    }
+
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/RelativeTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/RelativeTest.java
@@ -1,0 +1,14 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RelativeTest {
+
+    @Test
+    void relativeIsJustTheNodeLink() {
+        assertThat(new Relative(()-> "tableA.html").asString()).contains("tableA.html");
+    }
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/RelativeToDiagramTableNodeLinkFactoryBuilderTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/RelativeToDiagramTableNodeLinkFactoryBuilderTest.java
@@ -1,0 +1,14 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RelativeToDiagramTableNodeLinkFactoryBuilderTest {
+
+    @Test
+    void wrapReturnsTableNodeFactory() {
+        assertThat(new RelativeToDiagramTableNodeLinkFactoryBuilder(null).withTableNodeLinkFactory((t) -> () -> "yepp")).isInstanceOf(TableNodeLinkFactory.class);
+    }
+
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/RelativeToDiagramTableNodeLinkFactoryTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/RelativeToDiagramTableNodeLinkFactoryTest.java
@@ -1,0 +1,48 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.schemaspy.model.Table;
+import org.schemaspy.output.diagram.DiagramFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RelativeToDiagramTableNodeLinkFactoryTest {
+
+    private final DiagramFactory usingSvg = mock(DiagramFactory.class);
+    private final DiagramFactory usingPng = mock(DiagramFactory.class);
+
+    @BeforeEach
+    void setupMocks() {
+        when(usingSvg.getDiagramFormat()).thenReturn("svg");
+        when(usingPng.getDiagramFormat()).thenReturn("png");
+    }
+
+    @Test
+    void remoteTableUsingSVG() {
+        Table table = mock(Table.class);
+        when(table.isRemote()).thenReturn(true);
+        when(table.getName()).thenReturn("remoteTable");
+        when(table.getContainer()).thenReturn("schema");
+        assertThat(new RelativeToDiagramTableNodeLinkFactory(usingSvg, null).nodeLink(table).asString()).isEqualTo("../../../schema/tables/remoteTable.html");
+    }
+
+    @Test
+    void localTableUsingSVG() {
+        Table table = mock(Table.class);
+        when(table.isRemote()).thenReturn(false);
+        when(table.getName()).thenReturn("localTable");
+        assertThat(new RelativeToDiagramTableNodeLinkFactory(usingSvg, null).nodeLink(table).asString()).isEqualTo("../../tables/localTable.html");
+    }
+
+    @Test
+    void delegatesIfNotSVG() {
+        Table table = mock(Table.class);
+        when(table.isRemote()).thenReturn(false);
+        when(table.getName()).thenReturn("localTable");
+        assertThat(new RelativeToDiagramTableNodeLinkFactory(usingPng, (t) -> () -> "yepp").nodeLink(table).asString()).isEqualTo("yepp");
+    }
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/RelativeToDiagramTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/RelativeToDiagramTest.java
@@ -1,0 +1,14 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RelativeToDiagramTest {
+
+    @Test
+    void referenceTwoLevelsUpThenTables() {
+        assertThat(new RelativeToDiagram(() -> "tableA.html").asString()).isEqualTo("../../tables/tableA.html");
+    }
+
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/RemoteFromBaseTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/RemoteFromBaseTest.java
@@ -1,0 +1,20 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+import org.schemaspy.model.RemoteTable;
+import org.schemaspy.model.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RemoteFromBaseTest {
+
+    @Test
+    void backReferenceAndIncludeSchema() {
+        Table table = mock(RemoteTable.class);
+        when(table.getContainer()).thenReturn("schema");
+        assertThat(new RemoteFromBase(table, () -> "tableA.html").asString()).isEqualTo("../schema/tables/tableA.html");
+    }
+
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/RemoteRelativeTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/RemoteRelativeTest.java
@@ -1,0 +1,19 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+import org.schemaspy.model.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RemoteRelativeTest {
+
+    @Test
+    void backReference2TimesSchemaTablesTable() {
+        Table table = mock(Table.class);
+        when(table.getContainer()).thenReturn("schema");
+        assertThat(new RemoteRelative(table, () -> "tableA.html").asString()).isEqualTo("../../schema/tables/tableA.html");
+    }
+
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/RemoteRelativeToDiagramTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/RemoteRelativeToDiagramTest.java
@@ -1,0 +1,20 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+import org.schemaspy.model.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RemoteRelativeToDiagramTest {
+
+    @Test
+    void backReference3TimesSchemaTablesTableA() {
+        Table table = mock(Table.class);
+        when(table.getContainer()).thenReturn("schema");
+        assertThat(new RemoteRelativeToDiagram(table, () -> "tableA.html").asString()).isEqualTo("../../../schema/tables/tableA.html");
+    }
+
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/WithTargetTopTableNodeLinkFactoryTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/WithTargetTopTableNodeLinkFactoryTest.java
@@ -1,0 +1,16 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+import org.schemaspy.model.Table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class WithTargetTopTableNodeLinkFactoryTest {
+
+    @Test
+    void wrapNodeLinkInWithTargetTop() {
+        assertThat(new WithTargetTopTableNodeLinkFactory((t) -> () -> "yepp").nodeLink(mock(Table.class))).isInstanceOf(WithTargetTop.class);
+    }
+
+}

--- a/src/test/java/org/schemaspy/output/dot/schemaspy/link/WithTargetTopTest.java
+++ b/src/test/java/org/schemaspy/output/dot/schemaspy/link/WithTargetTopTest.java
@@ -1,0 +1,19 @@
+package org.schemaspy.output.dot.schemaspy.link;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WithTargetTopTest {
+
+    @Test
+    void containsTargetTop() {
+        assertThat(new WithTargetTop(() -> "").asString()).contains("target=\"_top\"");
+    }
+
+    @Test
+    void withUrlFromNodeLink() {
+        assertThat(new WithTargetTop(() -> "table.html").asString()).contains("URL=\"table.html\"");
+    }
+
+}


### PR DESCRIPTION
Link library to remove createPath() from DotNode

https://github.com/schemaspy/schemaspy/blob/5d2b8301b2cd83c52d10bd73639688582d20c6df/src/main/java/org/schemaspy/output/dot/schemaspy/DotNode.java#L78-L87

But also remove isOneOfMultipleSchemas()
https://github.com/schemaspy/schemaspy/blob/5d2b8301b2cd83c52d10bd73639688582d20c6df/src/main/java/org/schemaspy/output/dot/schemaspy/DotNode.java#L132-L135

Enabling us to remove useRelativeLinks() from 
Enabling us to remove isOneOfMultipleSchemas() from Config/DotConfig/HtmlConfig since it set in runtime and not config from cli. There are more places that needs changing.

```
RelativeToDiagramTableNodeLinkFactoryBuilder relativeToDiagramTableNodeLinkFactoryBuilder =
  new RelativeToDiagramTableNodeLinkFactoryBuilder(diagramFactory);
AddTableNodeLinkFactoryBuilder addTableNodeLinkFactoryBuilder =
  new AddTableNodeLinkFactoryBuilder(multiSchema);


MustacheSummaryDiagramFactory mustacheSummaryDiagramFactory =
  new MustacheSummaryDiagramFactory(
    new DotSummaryFormatter(
      dotConfig,
      addTableNodeLinkFactoryBuilder.withTableNodeLinkFactory(
        new WithTargetTopTableNodeLinkFactory(
          relativeToDiagramTableNodeLinkFactoryBuilder.withTableNodeLinkFactory(
            new FromBaseTableNodeLinkFactory()
          )
		)
      )
	),
    mustacheDiagramFactory,
    impliedConstraintsFinder,
    outputDir
  );

MustacheOrphanDiagramFactory mustacheOrphanDiagramFactory = 
  new MustacheOrphanDiagramFactory(
    dotConfig,
    addTableNodeLinkFactoryBuilder.withTableNodeLinkFactory(
      new WithTargetTopTableNodeLinkFactory(
        relativeToDiagramTableNodeLinkFactoryBuilder.withTableNodeLinkFactory(
          new FromBaseTableNodeLinkFactory()
        )
      )
    ),
    mustacheDiagramFactory,
    outputDir
  );

DotFormatter dotFormatter = 
  new DotFormatter(
    dotConfig, 
    addTableNodeLinkFactoryBuilder.withTableNodeLinkFactory(
      new WithTargetTopTableNodeLinkFactory(
        relativeToDiagramTableNodeLinkFactoryBuilder.withTableNodeLinkFactory(
          new RelativeTableNodeLinkFactory()
        )
      )
    )
  );
```