### PR TITLE
Include by default partitioned tables on PostgreSQL > 11

### DIFF
--- a/src/main/resources/org/schemaspy/types/pgsql11.properties
+++ b/src/main/resources/org/schemaspy/types/pgsql11.properties
@@ -20,6 +20,8 @@ description=PostgreSQL On Or After Version 11
 
 extends=pgsql
 
+tableTypes=TABLE,PARTITIONED TABLE
+
 selectRoutinesSql=select \
 r.routine_name || '(' || oidvectortypes(p.proargtypes) || ')' as routine_name, \
 case p.prokind when 'f' then 'FUNCTION' when 'p' then 'PROCEDURE' when 'a' then 'AGGREGATE' when 'w' then 'WINDOW' else 'UNKNOWN' end as routine_type, \


### PR DESCRIPTION
 [This comment](https://github.com/schemaspy/schemaspy/issues/717#issuecomment-668292768) proposed a workaround using externalized configuration file but I think partitioned tables should be returned by the tool by default for more simplicity.

resolves #717