### PR TITLE
Bump Spring-boot to v2.2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <argLine>-Dfile.encoding=UTF-8</argLine>
         <sonar.junit.reportPaths>target/surefire-reports,target/failsafe-reports</sonar.junit.reportPaths>
 
-        <spring-boot.version>2.1.2.RELEASE</spring-boot.version>
+        <spring-boot.version>2.2.11.RELEASE</spring-boot.version>
         <testcontainers-java.version>1.16.3</testcontainers-java.version>
         <testcontainers-junit.version>1.10.1.0.0</testcontainers-junit.version>
 


### PR DESCRIPTION
To mitigate CVE-2022-27772, we need to bump Spring-boot to version 2.2.11

Fix issue #993 