### PR TITLE
make vizjs to work with jdk15 or higher.

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -64,8 +64,6 @@ SchemaSpy version 6.1.0 and higher now comes with viz.js, so you will not need t
 
 For SchemaSpy version 6.1.0 or higher, simply include ``-vizjs`` as a command line argument when executing the SchemaSpy command.
 
-NOTE: If you are using Java 15 or later, ``vis.js`` will not work! This is because Nashorn (JavaScript engine) was removed on Java 15. Hence, if you are on Java 15 or later, you need to install Graphviz manually as described below. Or, you can switch to an earlier Java version if you would like to use ``vis.js``.
-
 If you must use Schemaspy version 6.0 or less, then Graphviz will need to be installed as follows.
 
 - Windows

--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,11 @@
             <artifactId>xalan</artifactId>
             <version>2.7.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.nashorn</groupId>
+            <artifactId>nashorn-core</artifactId>
+            <version>15.4</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/src/main/java/org/schemaspy/output/diagram/vizjs/VizJSDot.java
+++ b/src/main/java/org/schemaspy/output/diagram/vizjs/VizJSDot.java
@@ -45,7 +45,7 @@ public class VizJSDot implements Renderer {
                 throw new IllegalArgumentException("viz.js not found");
             }
             ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
-            scriptEngine = scriptEngineManager.getEngineByName("JavaScript");
+            scriptEngine = scriptEngineManager.getEngineByName("nashorn");
             scriptEngine.eval(IOUtils.toString(vizJs, StandardCharsets.UTF_8));
         } catch (Exception e) {
             throw new IllegalArgumentException("viz.js", e);


### PR DESCRIPTION
I added nashorn dependency for jdk15 or higher.
I couldn't find the contributor rules, so if there is a way to do it, please let me know.

### changes
- add dependency nashorn
- specify nashorn script-engine

### references
https://mvnrepository.com/artifact/org.openjdk.nashorn/nashorn-core/15.4
https://stackoverflow.com/questions/65265629/how-to-use-nashorn-in-java-15-and-later

