### PR TITLE
fix(h2-2): use start_value

### DIFF
--- a/src/main/resources/org/schemaspy/types/h2-2.properties
+++ b/src/main/resources/org/schemaspy/types/h2-2.properties
@@ -1,5 +1,5 @@
 dbms=H2
 extends=h2
 description=Server 2.0
-selectSequencesSql=SELECT seqs.sequence_name, (seqs.base_value + seqs.increment) as start_value, seqs.increment FROM information_schema.sequences seqs WHERE seqs.sequence_schema = :schema
+selectSequencesSql=SELECT seqs.sequence_name, seqs.start_value, seqs.increment FROM information_schema.sequences seqs WHERE seqs.sequence_schema = :schema
 tableTypes=BASE TABLE


### PR DESCRIPTION
* H2 1.x didn't have `start_value` it was introduced in 2.x
* 2.x is based of 1.x databaseType and as such it's inherited the workaround for `start_value`. It was overridden in 2.x since `current_value` has been replaced with `base_value` and 1.x during create set `current_value` to `START WITH - INCREMENT`, explains why it was `current_value + increment`

fixes #1012