### PR TITLE
chore(cli): store unknown options

### DIFF
--- a/src/main/java/org/schemaspy/cli/CommandLineArgumentParser.java
+++ b/src/main/java/org/schemaspy/cli/CommandLineArgumentParser.java
@@ -72,7 +72,7 @@ public class CommandLineArgumentParser {
 
     public CommandLineArguments parse(String... localArgs) {
         jCommander.parse(localArgs);
-
+        arguments.setUnknownArgs(jCommander.getUnknownOptions());
         if (shouldValidate()) {
             validate(arguments);
         }

--- a/src/main/java/org/schemaspy/cli/CommandLineArguments.java
+++ b/src/main/java/org/schemaspy/cli/CommandLineArguments.java
@@ -26,6 +26,8 @@ import org.schemaspy.output.diagram.graphviz.GraphvizConfig;
 import org.schemaspy.output.diagram.graphviz.GraphvizConfigCli;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Holds all supported command line arguments.
@@ -406,6 +408,8 @@ public class CommandLineArguments {
     )
     private boolean anomaliesLengthChange = false;
 
+    private List<String> unknownArgs;
+
     public boolean isHelpRequired() {
         return helpRequired;
     }
@@ -576,5 +580,13 @@ public class CommandLineArguments {
 
     public boolean isAnomaliesLengthChange() {
         return anomaliesLengthChange;
+    }
+
+    void setUnknownArgs(List<String> unknownArgs) {
+        this.unknownArgs = unknownArgs;
+    }
+
+    public List<String> unknownArgs() {
+        return Collections.unmodifiableList(unknownArgs);
     }
 }

--- a/src/test/java/org/schemaspy/cli/CommandLineArgumentParserTest.java
+++ b/src/test/java/org/schemaspy/cli/CommandLineArgumentParserTest.java
@@ -167,8 +167,9 @@ public class CommandLineArgumentParserTest {
         CommandLineArgumentParser parser = new CommandLineArgumentParser(new CommandLineArguments(), NO_DEFAULT_PROVIDER);
         parser.printLicense();
         String log = loggingRule.getLog();
-        assertThat(log).contains("GNU GENERAL PUBLIC LICENSE");
-        assertThat(log).contains("GNU LESSER GENERAL PUBLIC LICENSE");
+        assertThat(log)
+            .contains("GNU GENERAL PUBLIC LICENSE")
+            .contains("GNU LESSER GENERAL PUBLIC LICENSE");
     }
 
     @Test
@@ -256,6 +257,20 @@ public class CommandLineArgumentParserTest {
         assertThat(commandLine.isRoutineLengthChange()).isTrue();
         assertThat(commandLine.isFkLengthChange()).isFalse();
         assertThat(commandLine.isDbObjectLengthChange()).isFalse();
+    }
+
+    @Test
+    public void unkownOptionsAreStoredInArgument() {
+        String[] args = {
+            "-o", "aFolder",
+            "-sso",
+            "-server", "xds"
+        };
+        CommandLineArguments arguments = new CommandLineArgumentParser(
+            new CommandLineArguments(),
+            NO_DEFAULT_PROVIDER
+        ).parse(args);
+        assertThat(arguments.unknownArgs()).containsExactly("-server", "xds");
     }
 
     //TODO Implement integration tests (?) for following scenarios, addressing the behavior of ApplicationStartListener.


### PR DESCRIPTION
Ability to handle JCommander unknown options, such as defined in dbType