### PR TITLE
Initial support for Clickhouse

### DIFF
--- a/src/main/resources/org/schemaspy/types/clickhouse.properties
+++ b/src/main/resources/org/schemaspy/types/clickhouse.properties
@@ -1,0 +1,12 @@
+#
+# see http://schemaspy.org/dbtypes.html
+# for configuration / customization details
+#
+dbms=ClickHouse
+description=Standard
+connectionSpec=jdbc:clickhouse://<hostOptionalPort>/<db>
+host=host where database resides with optional port
+port=port database is listening on
+db=database name
+
+driver=com.clickhouse.jdbc.ClickHouseDriver


### PR DESCRIPTION
Provide SchemaSpy doc generation support for ClickHouse database via [clickhouse-jdbc](https://github.com/ClickHouse/clickhouse-java/tree/main/clickhouse-jdbc) 