### PR TITLE
fix(docs): path handling for rtd

### DIFF
--- a/docs/source/_ext/schemaspy_database_types.py
+++ b/docs/source/_ext/schemaspy_database_types.py
@@ -10,9 +10,11 @@ from sphinx.util.docutils import SphinxDirective
 
 class SchemaSpyDatabaseTypes(SphinxDirective):
 
-    types_path = join('..', 'src', 'main', 'resources', 'org', 'schemaspy', 'types')
+    types_path = join('src', 'main', 'resources', 'org', 'schemaspy', 'types')
 
     def run(self):
+        if os.getcwd().endswith('docs'):
+            self.types_path = join('..', self.types_path)
         db_types_grouped_by_dbms = self.load_database_types()
         table = self.create_table(db_types_grouped_by_dbms)
         return self.parse_rst(table)


### PR DESCRIPTION
* prepend path to database-types with `..` when building locally