### PR TITLE
chore(schemaanalyzer): clean up old multischema

### DIFF
--- a/src/main/java/org/schemaspy/Config.java
+++ b/src/main/java/org/schemaspy/Config.java
@@ -683,10 +683,6 @@ public final class Config implements HtmlConfig {
         return tableExclusions;
     }
 
-    public void setSchemas(List<String> schemas) {
-        this.schemas = schemas;
-    }
-
     /**
      * @return list of schemas to process
      */
@@ -709,10 +705,6 @@ public final class Config implements HtmlConfig {
         }
 
         return schemas;
-    }
-
-    public void setEvaluateAllEnabled(boolean enabled) {
-        evaluateAll = enabled;
     }
 
     public boolean isEvaluateAllEnabled() {

--- a/src/main/java/org/schemaspy/SchemaAnalyzer.java
+++ b/src/main/java/org/schemaspy/SchemaAnalyzer.java
@@ -154,8 +154,7 @@ public class SchemaAnalyzer {
             String schemaSpec = config.getSchemaSpec();
             Connection connection = new DbDriverLoader().getConnection(commandLineArguments, config);
             DatabaseMetaData meta = connection.getMetaData();
-            //-all(evaluteAll) given then get list of the database schemas
-            if (schemas == null || config.isEvaluateAllEnabled()) {
+            if (schemas == null) {
                 if (schemaSpec == null)
                     schemaSpec = ".*";
                 LOGGER.info(
@@ -179,9 +178,6 @@ public class SchemaAnalyzer {
             List<MustacheSchema> mustacheSchemas = new ArrayList<>();
             MustacheCatalog mustacheCatalog = null;
             for (String schema : schemas) {
-                // reset -all(evaluteAll) and -schemas parameter to avoid infinite loop! now we are analyzing single schema
-                config.setSchemas(null);
-                config.setEvaluateAllEnabled(false);
                 if (dbName == null)
                     config.setDb(schema);
 

--- a/src/main/java/org/schemaspy/input/dbms/service/SqlService.java
+++ b/src/main/java/org/schemaspy/input/dbms/service/SqlService.java
@@ -77,11 +77,6 @@ public class SqlService {
         dbmsMeta = dbmsService.fetchDbmsMeta(databaseMetaData);
         invalidIdentifierPattern = createInvalidIdentifierPattern(databaseMetaData);
         allKeywords = dbmsMeta.getAllKeywords();
-
-        if (config.isEvaluateAllEnabled()) {
-            return null;    // no database to return
-        }
-
         return databaseMetaData;
     }
 


### PR DESCRIPTION
* This is inheritance from when multi schema forked new SchemaSpy processes. Simply put multiSchema would call analyze(config) again, so the multi state had to be cleared before that.

* remove Config.setEvaluateAllEnabled
* remove Config.setSchemas

* sqlservice remove null return, since we aren't resetting isEvaluateAllEnabled.