### PR TITLE
chore(cli): set instead of list for schemas

### DIFF
--- a/src/main/java/org/schemaspy/cli/CommandLineArguments.java
+++ b/src/main/java/org/schemaspy/cli/CommandLineArguments.java
@@ -32,9 +32,7 @@ import org.schemaspy.view.HtmlConfig;
 import org.schemaspy.view.HtmlConfigCli;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 /**
  * Holds all supported command line arguments.
@@ -189,9 +187,10 @@ public class CommandLineArguments {
             "schemaspy.schemas", "schemaspy.schemata"
         },
         descriptionKey = "schemas",
-        listConverter = SchemasListConverter.class
+        converter = SchemasListConverter.class
     )
-    private List<String> schemas = Collections.emptyList();
+    //Use Set instead of List to workaround https://github.com/cbeust/jcommander/issues/457
+    private Set<String> schemas = new HashSet<>();
 
     @Parameter(
         names = {
@@ -543,7 +542,7 @@ public class CommandLineArguments {
     }
 
     public List<String> getSchemas() {
-        return schemas;
+        return new ArrayList<>(schemas);
     }
 
     public String getSchemaMeta() {

--- a/src/main/java/org/schemaspy/cli/PropertyFileDefaultProvider.java
+++ b/src/main/java/org/schemaspy/cli/PropertyFileDefaultProvider.java
@@ -21,12 +21,9 @@
 package org.schemaspy.cli;
 
 import com.beust.jcommander.IDefaultProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -44,8 +41,6 @@ import java.util.Properties;
  * @author Nils Petzaell
  */
 public class PropertyFileDefaultProvider implements IDefaultProvider {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final Properties properties;
 

--- a/src/main/java/org/schemaspy/cli/SchemasListConverter.java
+++ b/src/main/java/org/schemaspy/cli/SchemasListConverter.java
@@ -2,14 +2,14 @@ package org.schemaspy.cli;
 
 import com.beust.jcommander.IStringConverter;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
-public class SchemasListConverter implements IStringConverter<List<String>> {
+public class SchemasListConverter implements IStringConverter<Set<String>> {
 
     @Override
-    public List<String> convert(String value) {
-        List<String> schemas = new ArrayList<>();
+    public Set<String> convert(String value) {
+        Set<String> schemas = new HashSet<>();
         for (String name : value.split(",")) {
             if (name.length() > 0)
                 schemas.add(name);

--- a/src/test/java/org/schemaspy/cli/CommandLineArgumentsTest.java
+++ b/src/test/java/org/schemaspy/cli/CommandLineArgumentsTest.java
@@ -1,5 +1,6 @@
 package org.schemaspy.cli;
 
+import com.beust.jcommander.IDefaultProvider;
 import com.beust.jcommander.JCommander;
 import org.junit.jupiter.api.Test;
 
@@ -42,9 +43,29 @@ class CommandLineArgumentsTest {
             .isEmpty();
     }
 
+    @Test
+    void schemasDefaultFromDefaultsProvider() {
+        assertThat(
+            parse((optionName ->
+                optionName.equals("schemaspy.schemas")
+                    ? "a 1,a 2"
+                    : null)
+            )
+                .getSchemas()
+        )
+            .containsExactlyInAnyOrder("a 1", "a 2");
+    }
+
     private CommandLineArguments parse(String...args) {
+        return parse(optionName -> null, args);
+    }
+
+    private CommandLineArguments parse(IDefaultProvider iDefaultProvider, String...args) {
         CommandLineArguments commandLineArguments = new CommandLineArguments();
-        JCommander jCommander = JCommander.newBuilder().build();
+        JCommander jCommander = JCommander
+            .newBuilder()
+            .defaultProvider(iDefaultProvider)
+            .build();
         jCommander.addObject(commandLineArguments);
         jCommander.parse(args);
         return commandLineArguments;


### PR DESCRIPTION
* Bug in jcommander loads same default for each option name/alias https://github.com/cbeust/jcommander/issues/457