### PR TITLE
Configurable flexmark options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,12 +80,12 @@
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark</artifactId>
-                <version>0.34.32</version>
+                <version>0.64.0</version>
             </dependency>
             <dependency>
                 <groupId>com.vladsch.flexmark</groupId>
                 <artifactId>flexmark-profile-pegdown</artifactId>
-                <version>0.34.32</version>
+                <version>0.64.0</version>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>

--- a/src/main/java/org/schemaspy/util/FlexmarkJsOptions.java
+++ b/src/main/java/org/schemaspy/util/FlexmarkJsOptions.java
@@ -1,0 +1,45 @@
+/*
+ * This file is part of SchemaSpy.
+ *
+ * SchemaSpy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SchemaSpy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with SchemaSpy. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.schemaspy.util;
+
+import com.vladsch.flexmark.util.data.DataHolder;
+
+import java.io.FileReader;
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+
+/**
+ * Create flexmark options using java script
+ *
+ * @author Anselm Kruis
+ */
+public class FlexmarkJsOptions {
+    public static DataHolder getOptions() {
+        String jsFile = System.getProperty("schemaspy.flexmark.options.js");
+        if (null == jsFile) {
+            throw new RuntimeException("system property \"schemaspy.flexmark.options.js\" not set");
+        }
+        try {
+            ScriptEngine engine = new ScriptEngineManager().getEngineByName("nashorn");
+            engine.eval(new FileReader(jsFile));
+            return (DataHolder) (((Invocable) engine).invokeFunction("getOptions"));
+        } catch (Exception exc) {
+            throw new IllegalArgumentException("Failure to execute js function getOptions()", exc);
+        }
+    }
+}

--- a/src/main/java/org/schemaspy/util/Markdown.java
+++ b/src/main/java/org/schemaspy/util/Markdown.java
@@ -21,9 +21,9 @@ package org.schemaspy.util;
 
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
-import com.vladsch.flexmark.profiles.pegdown.Extensions;
-import com.vladsch.flexmark.profiles.pegdown.PegdownOptionsAdapter;
-import com.vladsch.flexmark.util.options.DataHolder;
+import com.vladsch.flexmark.profile.pegdown.Extensions;
+import com.vladsch.flexmark.profile.pegdown.PegdownOptionsAdapter;
+import com.vladsch.flexmark.util.data.DataHolder;
 import org.schemaspy.model.Table;
 import org.schemaspy.util.naming.FileNameGenerator;
 

--- a/src/main/java/org/schemaspy/util/Markdown.java
+++ b/src/main/java/org/schemaspy/util/Markdown.java
@@ -41,6 +41,22 @@ import java.util.regex.Pattern;
  * @author Daniel Watt
  */
 public class Markdown {
+    private static class FlexmarkOptionsHolder {
+        static final DataHolder options = computeOptionsValue();
+
+        private static DataHolder computeOptionsValue() {
+            String dataHolderClassName = System.getProperty("schemaspy.flexmark.options.class");
+            if (null == dataHolderClassName) {
+                return PegdownOptionsAdapter.flexmarkOptions(true,
+                           Extensions.ALL ^ Extensions.HARDWRAPS);
+            }
+            try {
+                return (DataHolder) Class.forName(dataHolderClassName).getDeclaredMethod("getOptions").invoke(null);
+            } catch (ReflectiveOperationException | SecurityException  exc) {
+                throw new RuntimeException(exc);
+            }
+        }
+    }
 
     private static final HashMap<String, String> pages = new HashMap<>();
 
@@ -53,9 +69,7 @@ public class Markdown {
         this(
                 markdownText,
                 rootPath,
-                PegdownOptionsAdapter.flexmarkOptions(true,
-                        Extensions.ALL ^ Extensions.HARDWRAPS
-                )
+                FlexmarkOptionsHolder.options
         );
     }
 


### PR DESCRIPTION
Hi,

we use schemaspy to document an internal database project. During the development it is very convenient to use the markdown editor of our Gitlab instance to write documentation for database objects using Gitlab-flavored markdown. Unfortunately schemaspy uses pegdown flavored markdown.

The flexmark processor is very flexible and can render many different markdown variants, but currently its configuration is hard wired. This merge request is a prove of concept to make the flexmark configuration an runtime option.

My Java is not the best any more and I'm not familiar with the implementation details of the schemaspy configuration. Therefore I used system properties instead of a proper integration with the schemaspy configuration. Clearly not production quality, but better than nothing.

CU Anselm