### PR TITLE
feature(Asciidoc): Allow the user to use Asciidoc as a markup language

### DIFF
--- a/docs/source/configuration/commandline.rst
+++ b/docs/source/configuration/commandline.rst
@@ -106,6 +106,8 @@ Html report related
     Use a custom stylesheet. Bundled stylesheet can be extracted from jar(using zip capable tool), path '/layout/schemaSpy.css'
 [-desc description]
     Add a description to the index page.
+[-asciidoc]
+    Uses asciidoc rather than markdown when processing descriptions
 
 DataTables related
 ------------------

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
                 <version>0.34.32</version>
             </dependency>
             <dependency>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctorj</artifactId>
+                <version>2.5.10</version>
+            </dependency>
+            <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
                 <version>20231013</version>
@@ -130,6 +135,10 @@
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
             <artifactId>flexmark-profile-pegdown</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj</artifactId>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -431,6 +431,12 @@
                 </executions>
                 <configuration>
                     <classifier>app</classifier>
+                    <requiresUnpack>
+                        <dependency>
+                            <groupId>org.asciidoctor</groupId>
+                            <artifactId>asciidoctorj</artifactId>
+                        </dependency>
+                    </requiresUnpack>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/schemaspy/SchemaAnalyzer.java
+++ b/src/main/java/org/schemaspy/SchemaAnalyzer.java
@@ -58,7 +58,9 @@ import org.schemaspy.progress.IfUpdateAfter;
 import org.schemaspy.util.DataTableConfig;
 import org.schemaspy.util.DefaultPrintWriter;
 import org.schemaspy.util.copy.CopyFromUrl;
+import org.schemaspy.util.markup.Asciidoc;
 import org.schemaspy.util.filefilter.NotHtml;
+import org.schemaspy.util.markup.Markdown;
 import org.schemaspy.util.naming.NameFromString;
 import org.schemaspy.util.naming.SanitizedFileName;
 import org.schemaspy.util.markup.MarkupProcessor;
@@ -337,6 +339,11 @@ public class SchemaAnalyzer {
         FileUtils.forceMkdir(new File(outputDir, "tables"));
         FileUtils.forceMkdir(new File(outputDir, "diagrams/summary"));
 
+        if(commandLineArguments.isAsciidoc()) {
+            MarkupProcessor.setInstance(new Asciidoc());
+        } else {
+            MarkupProcessor.setInstance(new Markdown());
+        }
         MarkupProcessor.getInstance().registryPage(tables);
 
         new CopyFromUrl(layoutFolder.url(), outputDir, new NotHtml()).copy();

--- a/src/main/java/org/schemaspy/SchemaAnalyzer.java
+++ b/src/main/java/org/schemaspy/SchemaAnalyzer.java
@@ -57,11 +57,11 @@ import org.schemaspy.progress.ConditionalProgress;
 import org.schemaspy.progress.IfUpdateAfter;
 import org.schemaspy.util.DataTableConfig;
 import org.schemaspy.util.DefaultPrintWriter;
-import org.schemaspy.util.Markdown;
 import org.schemaspy.util.copy.CopyFromUrl;
 import org.schemaspy.util.filefilter.NotHtml;
 import org.schemaspy.util.naming.NameFromString;
 import org.schemaspy.util.naming.SanitizedFileName;
+import org.schemaspy.util.markup.MarkupProcessor;
 import org.schemaspy.view.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -337,7 +337,7 @@ public class SchemaAnalyzer {
         FileUtils.forceMkdir(new File(outputDir, "tables"));
         FileUtils.forceMkdir(new File(outputDir, "diagrams/summary"));
 
-        Markdown.registryPage(tables);
+        MarkupProcessor.getInstance().registryPage(tables);
 
         new CopyFromUrl(layoutFolder.url(), outputDir, new NotHtml()).copy();
 

--- a/src/main/java/org/schemaspy/cli/CombinedDefaultProvider.java
+++ b/src/main/java/org/schemaspy/cli/CombinedDefaultProvider.java
@@ -33,6 +33,7 @@ public class CombinedDefaultProvider implements IDefaultProvider {
         "schemaspy.columnLengthChange",
         "schemaspy.noAnomaliesPaging",
         "schemaspy.anomaliesLengthChange",
+        "schemaspy.asciidoc",
         "schemaspy.norows", "schemaspy.no-rows",
         "schemaspy.noexportedkeys", "schemaspy.no-exported-keys",
         "schemaspy.noviews", "schemaspy.no-views"

--- a/src/main/java/org/schemaspy/cli/CommandLineArguments.java
+++ b/src/main/java/org/schemaspy/cli/CommandLineArguments.java
@@ -473,6 +473,15 @@ public class CommandLineArguments {
     )
     private boolean anomaliesLengthChange = false;
 
+    @Parameter(
+            names = {
+                    "-asciidoc", "--asciidoc",
+                    "schemaspy.asciidoc"
+            },
+            descriptionKey = "asciidoc"
+    )
+    private boolean asciidoc = false;
+
     public boolean isHelpRequired() {
         return helpRequired;
     }
@@ -667,6 +676,10 @@ public class CommandLineArguments {
 
     public boolean isAnomaliesLengthChange() {
         return anomaliesLengthChange;
+    }
+
+    public boolean isAsciidoc() {
+        return asciidoc;
     }
 
     void setUnknownArgs(List<String> unknownArgs) {

--- a/src/main/java/org/schemaspy/util/markup/Asciidoc.java
+++ b/src/main/java/org/schemaspy/util/markup/Asciidoc.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Samuel Dussault
+ *
+ * This file is part of SchemaSpy.
+ *
+ * SchemaSpy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SchemaSpy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with SchemaSpy. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.schemaspy.util.markup;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Attributes;
+import org.asciidoctor.Options;
+import org.w3c.dom.Attr;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Created by samdus on 2023-06-05
+ *
+ * @author Samuel Dussault
+ */
+public class Asciidoc extends MarkupProcessor {
+
+    @Override
+    protected String parseToHtml(String markupText) {
+        try(Asciidoctor asciidoctor = Asciidoctor.Factory.create()) {
+            return asciidoctor.convert(markupText, Options.builder().build());
+        }
+    }
+
+    @Override
+    protected String addReferenceLink(String markupText, String rootPath) {
+        final String regex = "xref:(.+)(\\[.+])";
+        final String string = "Refer to xref:document-b.adoc#section-b[Section B] for more information.";
+        final String subst = String.format("xref:%s/$1$2", rootPath);
+
+        final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
+        final Matcher matcher = pattern.matcher(string);
+
+        return matcher.replaceAll(subst);
+    }
+}

--- a/src/main/java/org/schemaspy/util/markup/Asciidoc.java
+++ b/src/main/java/org/schemaspy/util/markup/Asciidoc.java
@@ -46,7 +46,7 @@ public class Asciidoc extends MarkupProcessor {
     protected String addReferenceLink(String markupText, String rootPath) {
         final String regex = "xref:(.+)(\\[.+])";
         final String string = "Refer to xref:document-b.adoc#section-b[Section B] for more information.";
-        final String subst = String.format("xref:%s/$1$2", rootPath);
+        final String subst = String.format("xref:./%s/$1$2", rootPath);
 
         final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
         final Matcher matcher = pattern.matcher(string);

--- a/src/main/java/org/schemaspy/util/markup/Asciidoc.java
+++ b/src/main/java/org/schemaspy/util/markup/Asciidoc.java
@@ -44,12 +44,15 @@ public class Asciidoc extends MarkupProcessor {
 
     @Override
     protected String addReferenceLink(String markupText, String rootPath) {
+        if(rootPath == null || rootPath.length() == 0) {
+            return markupText;
+        }
+
         final String regex = "xref:(.+)(\\[.+])";
-        final String string = "Refer to xref:document-b.adoc#section-b[Section B] for more information.";
         final String subst = String.format("xref:./%s/$1$2", rootPath);
 
         final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
-        final Matcher matcher = pattern.matcher(string);
+        final Matcher matcher = pattern.matcher(markupText);
 
         return matcher.replaceAll(subst);
     }

--- a/src/main/java/org/schemaspy/util/markup/Asciidoc.java
+++ b/src/main/java/org/schemaspy/util/markup/Asciidoc.java
@@ -19,14 +19,7 @@
 package org.schemaspy.util.markup;
 
 import org.asciidoctor.Asciidoctor;
-import org.asciidoctor.Attributes;
 import org.asciidoctor.Options;
-import org.w3c.dom.Attr;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Created by samdus on 2023-06-05
@@ -42,18 +35,7 @@ public class Asciidoc extends MarkupProcessor {
         }
     }
 
-    @Override
-    protected String addReferenceLink(String markupText, String rootPath) {
-        if(rootPath == null || rootPath.length() == 0) {
-            return markupText;
-        }
-
-        final String regex = "xref:(.+)(\\[.+])";
-        final String subst = String.format("xref:./%s/$1$2", rootPath);
-
-        final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
-        final Matcher matcher = pattern.matcher(markupText);
-
-        return matcher.replaceAll(subst);
+    protected String formatLink(String pageName, String pagePath) {
+        return String.format("link:%s[%s]", pagePath, pageName);
     }
 }

--- a/src/main/java/org/schemaspy/util/markup/Markdown.java
+++ b/src/main/java/org/schemaspy/util/markup/Markdown.java
@@ -65,7 +65,7 @@ public class Markdown extends MarkupProcessor {
     }
 
     @Override
-    protected String parseToHtml(final String markupText, final String rootPath) {
+    protected String parseToHtml(final String markupText) {
         if (markupText == null) {
             return null;
         }

--- a/src/main/java/org/schemaspy/util/markup/Markdown.java
+++ b/src/main/java/org/schemaspy/util/markup/Markdown.java
@@ -25,16 +25,12 @@ import com.vladsch.flexmark.profiles.pegdown.Extensions;
 import com.vladsch.flexmark.profiles.pegdown.PegdownOptionsAdapter;
 import com.vladsch.flexmark.util.options.DataHolder;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 /**
  * Created by rkasa on 2016-04-11.
  *
  * @author Rafal Kasa
  * @author Daniel Watt
+ * @author Samuel Dussault
  */
 public class Markdown extends MarkupProcessor {
 
@@ -66,10 +62,6 @@ public class Markdown extends MarkupProcessor {
 
     @Override
     protected String parseToHtml(final String markupText) {
-        if (markupText == null) {
-            return null;
-        }
-
         return renderer.render(
             parser.parse(
                 markupText
@@ -77,43 +69,7 @@ public class Markdown extends MarkupProcessor {
         ).trim();
     }
 
-
-
-    @Override
-    protected String addReferenceLink(final String markupText, final String rootPath) {
-        StringBuilder text = new StringBuilder(markupText);
-        String newLine = "\r\n";
-
-        Pattern p = Pattern.compile("\\[(.*?)]");
-        Matcher m = p.matcher(markupText);
-
-        List<String> links = new ArrayList<>();
-
-        while(m.find()) {
-            links.add(m.group(1));
-        }
-
-        if (!links.isEmpty()) {
-            text.append(newLine).append(newLine);
-        }
-
-        for (String link : links) {
-            String anchorLink = "";
-            String pageLink = link;
-            int anchorPosition = link.lastIndexOf('.');
-
-            if (anchorPosition > -1) {
-                anchorLink = link.substring(anchorPosition + 1).trim();
-                pageLink = link.substring(0, anchorPosition);
-            }
-
-            String path = rootPath+pagePath(pageLink);
-            if (!"".equals(anchorLink)) {
-                path = path + "#" + anchorLink;
-            }
-            text.append("[").append(link).append("]: ./").append(path).append(newLine);
-        }
-
-        return text.toString();
+    protected String formatLink(String pageName, String pagePath) {
+        return String.format("[%1$s](%2$s)", pageName, pagePath);
     }
 }

--- a/src/main/java/org/schemaspy/util/markup/MarkupProcessor.java
+++ b/src/main/java/org/schemaspy/util/markup/MarkupProcessor.java
@@ -1,0 +1,51 @@
+package org.schemaspy.util.markup;
+
+import org.schemaspy.model.Table;
+import org.schemaspy.util.naming.NameFromString;
+import org.schemaspy.util.naming.SanitizedFileName;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Optional;
+
+public abstract class MarkupProcessor {
+    protected final HashMap<String, String> pages = new HashMap<>();
+
+    private static Optional<MarkupProcessor> instance = Optional.empty();
+
+    public static MarkupProcessor getInstance() {
+        if(!instance.isPresent()) {
+            instance = Optional.of(new Markdown());
+        }
+        return instance.get();
+    }
+
+    public static void setInstance(MarkupProcessor instance) {
+        MarkupProcessor.instance = Optional.of(instance);
+    }
+
+    public void registryPage(final Collection<Table> tables) {
+        final String DOT_HTML = ".html";
+        tables.stream()
+                .filter(table -> !table.isLogical())
+                .forEach(table -> {
+                    String tablePath = "tables/" + new SanitizedFileName(new NameFromString(table.getName())).value() + DOT_HTML;
+                    pages.put(table.getName(), tablePath);
+                });
+    }
+
+    public String pagePath(String page) {
+        return pages.get(page);
+    }
+
+    public String toHtml(final String markupText, final String rootPath) {
+        if(markupText == null) {
+            return null;
+        }
+        return parseToHtml(addReferenceLink(markupText, rootPath), rootPath).trim();
+    }
+
+    protected abstract String parseToHtml(final String markupText, final String rootPath);
+
+    protected abstract String addReferenceLink(final String markupText, final String rootPath);
+}

--- a/src/main/java/org/schemaspy/util/markup/MarkupProcessor.java
+++ b/src/main/java/org/schemaspy/util/markup/MarkupProcessor.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright (C) 2016 Rafal Kasa
+ * Copyright (C) 2017 Daniel Watt
+ * Copyright (C) 2023 Samuel Dussault
+ *
+ * This file is part of SchemaSpy.
+ *
+ * SchemaSpy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SchemaSpy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with SchemaSpy. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.schemaspy.util.markup;
 
 import org.schemaspy.model.Table;
@@ -8,6 +28,13 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Optional;
 
+/**
+ * Extracted from Markdown class by samdus on 2023-06-05
+ *
+ * @author Rafal Kasa
+ * @author Daniel Watt
+ * @author Samuel Dussault
+ */
 public abstract class MarkupProcessor {
     protected final HashMap<String, String> pages = new HashMap<>();
 
@@ -42,10 +69,10 @@ public abstract class MarkupProcessor {
         if(markupText == null) {
             return null;
         }
-        return parseToHtml(addReferenceLink(markupText, rootPath), rootPath).trim();
+        return parseToHtml(addReferenceLink(markupText, rootPath)).trim();
     }
 
-    protected abstract String parseToHtml(final String markupText, final String rootPath);
+    protected abstract String parseToHtml(final String markupText);
 
     protected abstract String addReferenceLink(final String markupText, final String rootPath);
 }

--- a/src/main/java/org/schemaspy/view/HtmlMainIndexPage.java
+++ b/src/main/java/org/schemaspy/view/HtmlMainIndexPage.java
@@ -27,7 +27,7 @@ import org.schemaspy.DbAnalyzer;
 import org.schemaspy.model.Database;
 import org.schemaspy.model.ForeignKeyConstraint;
 import org.schemaspy.model.Table;
-import org.schemaspy.util.Markdown;
+import org.schemaspy.util.markup.MarkupProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +67,7 @@ public class HtmlMainIndexPage {
 
         for(Table table: tables) {
             columnsAmount += table.getColumns().size();
-            String comments = new Markdown(table.getComments(), "").toHtml();
+            String comments = MarkupProcessor.getInstance().toHtml(table.getComments(), "");
             MustacheTable mustacheTable = new MustacheTable(table, "");
             mustacheTable.setComments(comments);
             mustacheTables.add(mustacheTable);
@@ -90,7 +90,7 @@ public class HtmlMainIndexPage {
                 .addToScope("anomaliesAmount", anomaliesAmount)
                 .addToScope("tables", mustacheTables)
                 .addToScope("database", database)
-                .addToScope("description", new Markdown(description, "").toHtml())
+                .addToScope("description", MarkupProcessor.getInstance().toHtml(description, ""))
                 .addToScope("schema", new MustacheSchema(database.getSchema(), ""))
                 .addToScope("catalog", new MustacheCatalog(database.getCatalog(), ""))
                 .addToScope("xmlName", getXmlName(database))

--- a/src/main/java/org/schemaspy/view/HtmlRoutinePage.java
+++ b/src/main/java/org/schemaspy/view/HtmlRoutinePage.java
@@ -20,7 +20,7 @@
 package org.schemaspy.view;
 
 import org.schemaspy.model.Routine;
-import org.schemaspy.util.Markdown;
+import org.schemaspy.util.markup.MarkupProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +47,7 @@ public class HtmlRoutinePage {
                 .templateName("routines/routine.html")
                 .scriptName("routine.js")
                 .addToScope("routineName", routine.getName())
-                .addToScope("routineComment", new Markdown(routine.getComment(), mustacheCompiler.getRootPath(1)).toHtml())
+                .addToScope("routineComment", MarkupProcessor.getInstance().toHtml(routine.getComment(), mustacheCompiler.getRootPath(1)))
                 .addToScope("routineParameters",routine.getParameters())
                 .addToScope("routineDefinition",routine.getDefinition())
                 .depth(1)

--- a/src/main/java/org/schemaspy/view/HtmlRoutinesPage.java
+++ b/src/main/java/org/schemaspy/view/HtmlRoutinesPage.java
@@ -22,7 +22,7 @@
 package org.schemaspy.view;
 
 import org.schemaspy.model.Routine;
-import org.schemaspy.util.Markdown;
+import org.schemaspy.util.markup.MarkupProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ public class HtmlRoutinesPage {
                 .templateName("routines.html")
                 .scriptName("routines.js")
                 .addToScope("routines", routines)
-                .addToScope("md2html", (Function<String,String>) md -> new Markdown(md, mustacheCompiler.getRootPath(0)).toHtml())
+                .addToScope("md2html", (Function<String,String>) md -> MarkupProcessor.getInstance().toHtml(md, mustacheCompiler.getRootPath(0)))
                 .getPageData();
 
         try {

--- a/src/main/java/org/schemaspy/view/HtmlTablePage.java
+++ b/src/main/java/org/schemaspy/view/HtmlTablePage.java
@@ -27,7 +27,7 @@ package org.schemaspy.view;
 import org.schemaspy.model.Table;
 import org.schemaspy.model.TableColumn;
 import org.schemaspy.model.TableIndex;
-import org.schemaspy.util.Markdown;
+import org.schemaspy.util.markup.MarkupProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,7 +84,7 @@ public class HtmlTablePage {
                 .templateName("tables/table.html")
                 .scriptName("table.js")
                 .addToScope("table", table)
-                .addToScope("comments", new Markdown(table.getComments(), mustacheCompiler.getRootPath(1)).toHtml())
+                .addToScope("comments", MarkupProcessor.getInstance().toHtml(table.getComments(), mustacheCompiler.getRootPath(1)))
                 .addToScope("primaries", primaries)
                 .addToScope("columns", tableColumns)
                 .addToScope("indexes", indexedColumns)

--- a/src/main/java/org/schemaspy/view/MustacheCatalog.java
+++ b/src/main/java/org/schemaspy/view/MustacheCatalog.java
@@ -19,7 +19,7 @@
 package org.schemaspy.view;
 
 import org.schemaspy.model.Catalog;
-import org.schemaspy.util.Markdown;
+import org.schemaspy.util.markup.MarkupProcessor;
 
 /**
  * Created by rkasa on 2016-12-17.
@@ -32,7 +32,7 @@ public class MustacheCatalog {
 
     public MustacheCatalog(Catalog catalog,String rootPath) {
         this.name = catalog.getName();
-        this.comment = new Markdown(catalog.getComment(), rootPath).toHtml();
+        this.comment = MarkupProcessor.getInstance().toHtml(catalog.getComment(), rootPath);
     }
 	
     public String getComment() {

--- a/src/main/java/org/schemaspy/view/MustacheSchema.java
+++ b/src/main/java/org/schemaspy/view/MustacheSchema.java
@@ -20,7 +20,7 @@
 package org.schemaspy.view;
 
 import org.schemaspy.model.Schema;
-import org.schemaspy.util.Markdown;
+import org.schemaspy.util.markup.MarkupProcessor;
 
 /**
  * Created by rkasa on 2016-12-17.
@@ -34,7 +34,7 @@ public class MustacheSchema {
 
     public MustacheSchema(Schema schema,String rootPath) {
         this.name = schema.getName();
-        this.comment = new Markdown(schema.getComment(), rootPath).toHtml();
+        this.comment = MarkupProcessor.getInstance().toHtml(schema.getComment(), rootPath);
     }
 
     public String getName() {

--- a/src/main/java/org/schemaspy/view/MustacheTableColumn.java
+++ b/src/main/java/org/schemaspy/view/MustacheTableColumn.java
@@ -21,7 +21,7 @@ package org.schemaspy.view;
 
 import org.schemaspy.model.ForeignKeyConstraint;
 import org.schemaspy.model.TableColumn;
-import org.schemaspy.util.Markdown;
+import org.schemaspy.util.markup.MarkupProcessor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -150,7 +150,7 @@ public class MustacheTableColumn {
 
     public String getComments() {
         String comments = column.getComments();
-        comments = new Markdown(comments, rootPath).toHtml();
+        comments = MarkupProcessor.getInstance().toHtml(comments, rootPath);
         return comments;
     }
 

--- a/src/main/resources/commandlinearguments.properties
+++ b/src/main/resources/commandlinearguments.properties
@@ -49,3 +49,5 @@ columnLengthChange="Whether users can change the page length for routines"
 noAnomaliesPaging="Whether DataTables for anomalies should have pagination"
 anomaliesPageLength = "The DataTables pageLength for anomalies"
 anomaliesLengthChange="Whether users can change the page length for anomalies"
+
+asciidoc="Format descriptions using asciidoc rather than Markdown"

--- a/src/test/java/org/schemaspy/cli/CommandLineArgumentParserTest.java
+++ b/src/test/java/org/schemaspy/cli/CommandLineArgumentParserTest.java
@@ -265,7 +265,7 @@ class CommandLineArgumentParserTest {
     }
 
     @Test
-    void unkownOptionsAreStoredInArgument() {
+    void unknownOptionsAreStoredInArgument() {
         String[] args = {
             "-o", "aFolder",
             "-sso",
@@ -276,6 +276,51 @@ class CommandLineArgumentParserTest {
                 args
         ).commandLineArguments();
         assertThat(arguments.getConnectionConfig().getRemainingArguments()).containsExactly("-server", "xds");
+    }
+
+    @Test
+    void asciidocOptionIsOptional() {
+        String[] args = {
+            "-o", "aFolder",
+            "-sso"
+        };
+
+        CommandLineArguments commandLineArguments = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER, args).commandLineArguments();
+        assertThat(commandLineArguments.isAsciidoc()).isFalse();
+    }
+
+    @Test
+    void asciidocOptionEnabledByArg() {
+        String[] args = {
+            "-o", "aFolder",
+            "-sso",
+            "-asciidoc"
+        };
+
+        CommandLineArguments commandLineArguments = new CommandLineArgumentParser(NO_DEFAULT_PROVIDER, args).commandLineArguments();
+        assertThat(commandLineArguments.isAsciidoc()).isTrue();
+    }
+
+    @Test
+    void asciidocOptionEnabledByProperty() {
+        String[] args = {
+            "-o", "aFolder",
+            "-sso"
+        };
+
+        CommandLineArguments commandLineArguments =
+            new CommandLineArgumentParser(
+                new CombinedDefaultProvider(
+                    (string) -> {
+                        if ("schemaspy.asciidoc".equals(string)) {
+                            return "";
+                        }
+                        return null;
+                    }
+                ),
+                args
+            ).commandLineArguments();
+        assertThat(commandLineArguments.isAsciidoc()).isTrue();
     }
 
     //TODO Implement integration tests (?) for following scenarios, addressing the behavior of ApplicationStartListener.

--- a/src/test/java/org/schemaspy/integrationtesting/MarkupProcessorIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/MarkupProcessorIT.java
@@ -26,7 +26,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.sql.SQLException;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,8 +38,8 @@ import static org.schemaspy.testing.SchemaSpyRunnerFixture.schemaSpyRunner;
 class MarkupProcessorIT {
 
     @Test
-    void defaultMarkupIsMarkdown() throws SQLException, IOException {
-        Path outDir = Paths.get("target","integrationtesting","sqlite-markdown");
+    void defaultMarkupIsMarkdown() throws IOException {
+        Path outDir = Paths.get("target","testout", "integrationtesting","sqlite-markdown");
         String description = "## Title in Markdown";
         String expectedHtmlDescription = "<h2><a href=\"#title-in-markdown\" id=\"title-in-markdown\">Title in Markdown</a></h2>";
 
@@ -62,8 +61,8 @@ class MarkupProcessorIT {
     }
 
     @Test
-    void asciiDocParameterGeneratesHtmlFromAsciidocDescription() throws SQLException, IOException {
-        Path outDir = Paths.get("target","integrationtesting","sqlite-asciidoc");
+    void asciiDocParameterGeneratesHtmlFromAsciidocDescription() throws IOException {
+        Path outDir = Paths.get("target","testout", "integrationtesting","sqlite-asciidoc");
         String description = "== Title in Asciidoc";
         String expectedHtmlDescription = "<h2 id=\"_title_in_asciidoc\">Title in Asciidoc</h2>";
 

--- a/src/test/java/org/schemaspy/integrationtesting/MarkupProcessorIT.java
+++ b/src/test/java/org/schemaspy/integrationtesting/MarkupProcessorIT.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2019 Nils Petzaell
+ * Copyright (C) 2023 Samuel Dussault
+ *
+ * This file is part of SchemaSpy.
+ *
+ * SchemaSpy is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * SchemaSpy is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with SchemaSpy. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.schemaspy.integrationtesting;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.SQLException;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.schemaspy.testing.SchemaSpyRunnerFixture.schemaSpyRunner;
+
+/**
+ * @author Nils Petzaell
+ * @author Samuel Dussault
+ */
+class MarkupProcessorIT {
+
+    @Test
+    void defaultMarkupIsMarkdown() throws SQLException, IOException {
+        Path outDir = Paths.get("target","integrationtesting","sqlite-markdown");
+        String description = "## Title in Markdown";
+        String expectedHtmlDescription = "<h2><a href=\"#title-in-markdown\" id=\"title-in-markdown\">Title in Markdown</a></h2>";
+
+        String[] args = {
+                "-t", "sqlite-xerial",
+                "-db", "src/test/resources/integrationTesting/sqlite/database/chinook.db",
+                "-s", "chinook",
+                "-cat", "chinook",
+                "-o", outDir.toString(),
+                "-sso",
+                "-vizjs",
+                "-desc", description
+        };
+        schemaSpyRunner(args).run();
+
+        String actualHtml = read(outDir.resolve("index.html"));
+
+        assertThat(actualHtml).contains(expectedHtmlDescription);
+    }
+
+    @Test
+    void asciiDocParameterGeneratesHtmlFromAsciidocDescription() throws SQLException, IOException {
+        Path outDir = Paths.get("target","integrationtesting","sqlite-asciidoc");
+        String description = "== Title in Asciidoc";
+        String expectedHtmlDescription = "<h2 id=\"_title_in_asciidoc\">Title in Asciidoc</h2>";
+
+        String[] args = {
+                "-t", "sqlite-xerial",
+                "-db", "src/test/resources/integrationTesting/sqlite/database/chinook.db",
+                "-s", "chinook",
+                "-cat", "chinook",
+                "-o", outDir.toString(),
+                "-sso",
+                "-vizjs",
+                "-asciidoc",
+                "-desc", description
+        };
+        schemaSpyRunner(args).run();
+
+        String actualHtml = read(outDir.resolve("index.html"));
+
+        assertThat(actualHtml).contains(expectedHtmlDescription);
+    }
+
+    private String read(Path filePath) throws IOException {
+        StringBuilder builder = new StringBuilder();
+        try (Stream<String> stream = Files.lines(filePath, StandardCharsets.UTF_8)) {
+            stream.forEach(s -> builder.append(s).append("\n"));
+        }
+        return builder.toString();
+    }
+}

--- a/src/test/java/org/schemaspy/util/MarkdownTest.java
+++ b/src/test/java/org/schemaspy/util/MarkdownTest.java
@@ -1,6 +1,7 @@
 package org.schemaspy.util;
 
 import org.junit.jupiter.api.Test;
+import org.schemaspy.util.markup.MarkupProcessor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -9,14 +10,14 @@ class MarkdownTest {
     @Test
     void willNotReplaceDirectNewLineToBR() {
         String sourceMarkdown = "Line\n with\n no\n hardbreak\n";
-        String renderedMarkdown = new Markdown(sourceMarkdown, ".").toHtml();
+        String renderedMarkdown = MarkupProcessor.getInstance().toHtml(sourceMarkdown, ".");
         assertThat(renderedMarkdown).doesNotContain("<br />");
     }
 
     @Test
     void willReplaceNewLineWhenPrecededByTwoSpacesAsBR() {
         String sourceMarkdown = "Line  \n with  \n no  \n hardbreak  \n";
-        String renderedMarkdown = new Markdown(sourceMarkdown, ".").toHtml();
+        String renderedMarkdown = MarkupProcessor.getInstance().toHtml(sourceMarkdown, ".");
         assertThat(renderedMarkdown).contains("<br />");
     }
 }

--- a/src/test/java/org/schemaspy/util/MarkdownTest.java
+++ b/src/test/java/org/schemaspy/util/MarkdownTest.java
@@ -1,7 +1,7 @@
 package org.schemaspy.util;
 
 import org.junit.jupiter.api.Test;
-import org.schemaspy.util.markup.MarkupProcessor;
+import org.schemaspy.util.markup.Markdown;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -10,14 +10,14 @@ class MarkdownTest {
     @Test
     void willNotReplaceDirectNewLineToBR() {
         String sourceMarkdown = "Line\n with\n no\n hardbreak\n";
-        String renderedMarkdown = MarkupProcessor.getInstance().toHtml(sourceMarkdown, ".");
+        String renderedMarkdown = new Markdown().toHtml(sourceMarkdown, ".");
         assertThat(renderedMarkdown).doesNotContain("<br />");
     }
 
     @Test
     void willReplaceNewLineWhenPrecededByTwoSpacesAsBR() {
         String sourceMarkdown = "Line  \n with  \n no  \n hardbreak  \n";
-        String renderedMarkdown = MarkupProcessor.getInstance().toHtml(sourceMarkdown, ".");
+        String renderedMarkdown = new Markdown().toHtml(sourceMarkdown, ".");
         assertThat(renderedMarkdown).contains("<br />");
     }
 }

--- a/src/test/java/org/schemaspy/util/markup/AsciidocTest.java
+++ b/src/test/java/org/schemaspy/util/markup/AsciidocTest.java
@@ -46,7 +46,7 @@ class AsciidocTest {
                 "<p>Refer to <a href=\"./schema2/document-b.html#section-b\">Section B</a> for more information.</p>\n" +
                 "</div>";
 
-        String actualHtml = new Asciidoc().toHtml(sourceAsciiDoc, "./schema2");
+        String actualHtml = new Asciidoc().toHtml(sourceAsciiDoc, "schema2");
         assertThat(actualHtml).isEqualTo(expectedHtml);
     }
 }

--- a/src/test/java/org/schemaspy/util/markup/AsciidocTest.java
+++ b/src/test/java/org/schemaspy/util/markup/AsciidocTest.java
@@ -1,0 +1,52 @@
+package org.schemaspy.util.markup;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AsciidocTest {
+
+    @Test
+    void toHtmlTest() {
+        String sourceAsciiDoc = ":seq1: {counter:seq1}\n" +
+                "== Section {seq1}\n" +
+                "\n" +
+                "The sequence in this section is {seq1}.\n" +
+                "\n" +
+                ":seq1: {counter:seq1}\n" +
+                "== Section {seq1}\n" +
+                "\n" +
+                "The sequence in this section is {seq1}.";
+        String expectedHtml = "<div class=\"sect1\">\n" +
+                "<h2 id=\"_section_1\">Section 1</h2>\n" +
+                "<div class=\"sectionbody\">\n" +
+                "<div class=\"paragraph\">\n" +
+                "<p>The sequence in this section is 1.</p>\n" +
+                "</div>\n" +
+                "</div>\n" +
+                "</div>\n" +
+                "<div class=\"sect1\">\n" +
+                "<h2 id=\"_section_2\">Section 2</h2>\n" +
+                "<div class=\"sectionbody\">\n" +
+                "<div class=\"paragraph\">\n" +
+                "<p>The sequence in this section is 2.</p>\n" +
+                "</div>\n" +
+                "</div>\n" +
+                "</div>";
+
+        String actualHtml = new Asciidoc().toHtml(sourceAsciiDoc, ".");
+        assertThat(actualHtml).isEqualTo(expectedHtml);
+    }
+
+    @Test
+    void referenceLinksAreHandledProperly() {
+        String sourceAsciiDoc = "Refer to xref:document-b.adoc#section-b[Section B] for more information.";
+        String expectedHtml = "<div class=\"paragraph\">\n" +
+                "<p>Refer to <a href=\"./schema2/document-b.html#section-b\">Section B</a> for more information.</p>\n" +
+                "</div>";
+
+        String actualHtml = new Asciidoc().toHtml(sourceAsciiDoc, "./schema2");
+        assertThat(actualHtml).isEqualTo(expectedHtml);
+    }
+}

--- a/src/test/java/org/schemaspy/util/markup/AsciidocTest.java
+++ b/src/test/java/org/schemaspy/util/markup/AsciidocTest.java
@@ -3,7 +3,6 @@ package org.schemaspy.util.markup;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 class AsciidocTest {
 
@@ -36,17 +35,6 @@ class AsciidocTest {
                 "</div>";
 
         String actualHtml = new Asciidoc().toHtml(sourceAsciiDoc, ".");
-        assertThat(actualHtml).isEqualTo(expectedHtml);
-    }
-
-    @Test
-    void referenceLinksAreHandledProperly() {
-        String sourceAsciiDoc = "Refer to xref:document-b.adoc#section-b[Section B] for more information.";
-        String expectedHtml = "<div class=\"paragraph\">\n" +
-                "<p>Refer to <a href=\"./schema2/document-b.html#section-b\">Section B</a> for more information.</p>\n" +
-                "</div>";
-
-        String actualHtml = new Asciidoc().toHtml(sourceAsciiDoc, "schema2");
         assertThat(actualHtml).isEqualTo(expectedHtml);
     }
 }

--- a/src/test/java/org/schemaspy/util/markup/MarkdownTest.java
+++ b/src/test/java/org/schemaspy/util/markup/MarkdownTest.java
@@ -1,7 +1,6 @@
-package org.schemaspy.util;
+package org.schemaspy.util.markup;
 
 import org.junit.jupiter.api.Test;
-import org.schemaspy.util.markup.Markdown;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/org/schemaspy/util/markup/MarkupProcessorTest.java
+++ b/src/test/java/org/schemaspy/util/markup/MarkupProcessorTest.java
@@ -1,0 +1,81 @@
+package org.schemaspy.util.markup;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.schemaspy.model.Table;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+public class MarkupProcessorTest {
+
+    private static Stream<MarkupProcessor> provideMarkupProcessors() {
+        return Stream.of(new Markdown(), new Asciidoc());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideMarkupProcessors")
+    public void replaceLinksWithExistingTablesAndDefaultRootPathTest(MarkupProcessor markupProcessor) {
+        String sourceMarkdown = "See [table1] or [table2.column]";
+        String expected = "<p>See <a href=\"./tables/table1.html\">table1</a>" +
+                " or <a href=\"./tables/table2.html#column\">table2.column</a></p>";
+
+        Collection<Table> tables = new ArrayList<>();
+        Table table1 = mock(Table.class);
+        given(table1.isLogical()).willReturn(false);
+        given(table1.getName()).willReturn("table1");
+        tables.add(table1);
+
+        Table table2 = mock(Table.class);
+        given(table2.isLogical()).willReturn(false);
+        given(table2.getName()).willReturn("table2");
+        tables.add(table2);
+
+        markupProcessor.registryPage(tables);
+
+        String actual = markupProcessor.toHtml(sourceMarkdown, "");
+
+        assertThat(actual).contains(expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideMarkupProcessors")
+    public void replaceLinksWithExistingTablesAndOtherRootPathTest(MarkupProcessor markupProcessor) {
+        String sourceMarkdown = "See [table1] or [table2.column]";
+        String expected = "<p>See <a href=\"../root/tables/table1.html\">table1</a>" +
+                " or <a href=\"../root/tables/table2.html#column\">table2.column</a></p>";
+
+        Collection<Table> tables = new ArrayList<>();
+        Table table1 = mock(Table.class);
+        given(table1.isLogical()).willReturn(false);
+        given(table1.getName()).willReturn("table1");
+        tables.add(table1);
+
+        Table table2 = mock(Table.class);
+        given(table2.isLogical()).willReturn(false);
+        given(table2.getName()).willReturn("table2");
+        tables.add(table2);
+
+        markupProcessor.registryPage(tables);
+
+        String actual = markupProcessor.toHtml(sourceMarkdown, "../root");
+
+        assertThat(actual).contains(expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideMarkupProcessors")
+    public void dontReplaceLinksWhenTableDoesntExists(MarkupProcessor markupProcessor) {
+        String sourceMarkdown = "See [table1.column]";
+        String expected = "<p>See [table1.column]</p>";
+
+        String actual = markupProcessor.toHtml(sourceMarkdown, "");
+
+        assertThat(actual).contains(expected);
+    }
+}


### PR DESCRIPTION
We are currently using Asciidoc rather than Markdown to document our databases. This PR adds a new parameter (-asciidoc) that replaces the usages of the Markdown class with the Asciidoc class.

### Implementation details
* Change the pages hashmap singleton with a singleton that encloses the complete MarkupProcessor
* Defaults to Markdown
* Adds a -asciidoc parameter
* Changes the way the reference links are handled to uniformize markdown processing with asciidoc
** Rather than adding `[link]: path` at the end of the Markdown string, it replaces the `[link]` directly.

### Bugfixes
* It also fixes #938
 