### PR TITLE
chore!: remove buildNumber.properties

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -47,6 +47,7 @@ jobs:
           -P release
           clean
           deploy
+          -Dscm.revision=$GITHUB_SHA
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,6 +32,7 @@ jobs:
           --show-version
           -P release
           verify
+          -Dscm.revision=$GITHUB_SHA
       - name: Upload test output
         uses: actions/upload-artifact@v3
         if: failure()

--- a/buildNumber.properties
+++ b/buildNumber.properties
@@ -1,3 +1,0 @@
-#maven.buildNumber.plugin properties file
-#Tue Dec 12 15:37:44 CST 2017
-buildNumber=40

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 
         <java.version>17</java.version>
         <skip.surefire>false</skip.surefire>
+        <scm.revision>${project.scm.tag}</scm.revision>
     </properties>
     <issueManagement>
         <url>https://github.com/schemaspy/schemaspy/issues</url>
@@ -387,9 +388,13 @@
                 <version>3.2.0</version>
                 <configuration>
                     <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                            <addBuildEnvironmentEntries>true</addBuildEnvironmentEntries>
+                        </manifest>
                         <manifestEntries>
-                            <Implementation-Version>${project.version}</Implementation-Version>
-                            <Implementation-Build>${buildNumber}</Implementation-Build>
+                            <Implementation-Revision>${scm.revision}</Implementation-Revision>
                         </manifestEntries>
                     </archive>
                 </configuration>
@@ -417,27 +422,6 @@
                         <nonFilteredFileExtension>woff</nonFilteredFileExtension>
                         <nonFilteredFileExtension>woff2</nonFilteredFileExtension>
                     </nonFilteredFileExtensions>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>buildnumber-maven-plugin</artifactId>
-                <version>1.4</version>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>create</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <doCheck>true</doCheck>
-                    <format>${project.version}.{0,number} {1,date,yyyy-MM-dd HH:mm:ss}</format>
-                    <items>
-                        <item>buildNumber</item>
-                        <item>timestamp</item>
-                    </items>
                 </configuration>
             </plugin>
             <plugin>
@@ -490,7 +474,7 @@
                     </excludes>
                     <systemPropertyVariables>
                         <pomImplementationVersion>${project.version}</pomImplementationVersion>
-                        <pomImplementationBuild>${buildNumber}</pomImplementationBuild>
+                        <pomImplementationRevision>${scm.revision}</pomImplementationRevision>
                         <oracle.jdbc.timezoneAsRegion>false</oracle.jdbc.timezoneAsRegion>
                     </systemPropertyVariables>
                 </configuration>

--- a/src/main/java/org/schemaspy/SchemaAnalyzer.java
+++ b/src/main/java/org/schemaspy/SchemaAnalyzer.java
@@ -351,7 +351,7 @@ public class SchemaAnalyzer {
         writeInfo("date", ZonedDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ssZ")), htmlInfoFile);
         writeInfo("os", System.getProperty("os.name") + " " + System.getProperty("os.version"), htmlInfoFile);
         writeInfo("schemaspy-version", ManifestUtils.getImplementationVersion(), htmlInfoFile);
-        writeInfo("schemaspy-build", ManifestUtils.getImplementationBuild(), htmlInfoFile);
+        writeInfo("schemaspy-revision", ManifestUtils.getImplementationRevision(), htmlInfoFile);
         writeInfo("renderer", renderer.identifier(), htmlInfoFile);
         progressListener.graphingSummaryProgressed();
 

--- a/src/main/java/org/schemaspy/util/ManifestUtils.java
+++ b/src/main/java/org/schemaspy/util/ManifestUtils.java
@@ -59,7 +59,7 @@ public class ManifestUtils {
         return Optional.ofNullable(manifestAttributes.getValue("Implementation-Version")).orElse("IDE");
     }
 
-    public static String getImplementationBuild() {
-        return Optional.ofNullable(manifestAttributes.getValue("Implementation-Build")).orElse("IDE");
+    public static String getImplementationRevision() {
+        return Optional.ofNullable(manifestAttributes.getValue("Implementation-Revision")).orElse("IDE");
     }
 }

--- a/src/test/java/org/schemaspy/testing/ClassAvailableCondition.java
+++ b/src/test/java/org/schemaspy/testing/ClassAvailableCondition.java
@@ -1,0 +1,51 @@
+package org.schemaspy.testing;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.disabled;
+import static org.junit.jupiter.api.extension.ConditionEvaluationResult.enabled;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+public class ClassAvailableCondition implements ExecutionCondition {
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        return findAnnotation(
+                context.getElement(),
+                EnableIfClassAvailable.class
+        )
+                .map(this::check)
+                .orElseGet(this::enabledByDefault);
+    }
+
+    private ConditionEvaluationResult check(EnableIfClassAvailable annotation) {
+        String missing = Stream
+                .of(annotation.value())
+                .filter(this::isMissing)
+                .collect(Collectors.joining(", "));
+        return missing.isEmpty()
+                ? enabled("All required classes are present")
+                : disabled(String.format("%s are missing", missing));
+    }
+
+    private boolean isMissing(String fullClassName) {
+        try {
+            Class.forName(fullClassName);
+            return false;
+        } catch (ClassNotFoundException e) {
+            return true;
+        }
+    }
+
+    private ConditionEvaluationResult enabledByDefault() {
+        String reason = String.format(
+                "@%s is not present",
+                EnableIfClassAvailable.class.getSimpleName()
+        );
+        return enabled(reason);
+    }
+}

--- a/src/test/java/org/schemaspy/testing/EnableIfClassAvailable.java
+++ b/src/test/java/org/schemaspy/testing/EnableIfClassAvailable.java
@@ -1,0 +1,20 @@
+package org.schemaspy.testing;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(ClassAvailableCondition.class)
+public @interface EnableIfClassAvailable {
+    /**
+     * Array of fully qualified class names that
+     * controls if this test is enabled.
+     * @return classes that need to be available.
+     */
+    String[] value();
+}

--- a/src/test/java/org/schemaspy/util/ManifestUtilsIT.java
+++ b/src/test/java/org/schemaspy/util/ManifestUtilsIT.java
@@ -18,16 +18,13 @@
  */
 package org.schemaspy.util;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.schemaspy.testing.AssumeClassIsPresentRule;
+import org.junit.jupiter.api.Test;
+import org.schemaspy.testing.EnableIfClassAvailable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 //Only run from maven
+@EnableIfClassAvailable("org.apache.maven.surefire.booter.StartupConfiguration")
 public class ManifestUtilsIT {
-
-    @ClassRule
-    public static AssumeClassIsPresentRule rule = new AssumeClassIsPresentRule("org.apache.maven.surefire.providerapi.SurefireProvider");
 
     @Test
     public void getImplementationVersion() {
@@ -36,6 +33,6 @@ public class ManifestUtilsIT {
 
     @Test
     public void getImplementationBuild() {
-        assertThat(ManifestUtils.getImplementationBuild()).isEqualTo(System.getProperty("pomImplementationBuild"));
+        assertThat(ManifestUtils.getImplementationRevision()).isEqualTo(System.getProperty("pomImplementationRevision"));
     }
 }

--- a/src/test/java/org/schemaspy/util/ManifestUtilsTest.java
+++ b/src/test/java/org/schemaspy/util/ManifestUtilsTest.java
@@ -18,7 +18,7 @@
  */
 package org.schemaspy.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,7 +30,7 @@ public class ManifestUtilsTest {
     }
 
     @Test
-    public void getImplementationBuild() {
-        assertThat(ManifestUtils.getImplementationBuild()).isEqualTo("IDE");
+    public void getImplementationRevision() {
+        assertThat(ManifestUtils.getImplementationRevision()).isEqualTo("IDE");
     }
 }


### PR DESCRIPTION
* remove buildnumber-maven-plugin
* remove Implementation-Build
* add additional metadata to jar manifest
* add Implementation-Revision based on ${project.scm.tag} or -Dscm.revision

BREAKING CHANGE: Implementation-Build replaced by Implementation-Revision which is either commit sha or tag.

Old Manifest
```
Manifest-Version: 1.0
Created-By: Maven Jar Plugin 3.2.0
Build-Jdk-Spec: 11
Implementation-Build: 6.2.4.41 2023-07-21 11:24:46
Implementation-Version: 6.2.4
Main-Class: org.springframework.boot.loader.JarLauncher
Start-Class: org.schemaspy.Main
Spring-Boot-Version: 2.2.11.RELEASE
Spring-Boot-Classes: BOOT-INF/classes/
Spring-Boot-Lib: BOOT-INF/lib/
```
New Manifest
```
Manifest-Version: 1.0
Created-By: Maven Jar Plugin 3.2.0
Build-Jdk-Spec: 17
Build-Tool: Apache Maven 3.8.1 (05c21c65bdfed0f71a2f2ada8b84da59348c4c5d
 )
Build-Jdk: 17.0.7 (Eclipse Adoptium)
Build-Os: Mac OS X (13.4.1; aarch64)
Specification-Title: SchemaSpy
Specification-Version: 7.0
Implementation-Title: SchemaSpy
Implementation-Version: 7.0.0-SNAPSHOT
Implementation-Revision: 464da35b2139c80dcb17c6dc1fd5d74a555135c5
Main-Class: org.springframework.boot.loader.JarLauncher
Start-Class: org.schemaspy.Main
Spring-Boot-Version: 3.1.2
Spring-Boot-Classes: BOOT-INF/classes/
Spring-Boot-Lib: BOOT-INF/lib/
Spring-Boot-Classpath-Index: BOOT-INF/classpath.idx
Spring-Boot-Layers-Index: BOOT-INF/layers.idx
```