### PR TITLE
Added LZ4 compression dependency, necessary for Clickhouse compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,11 @@
             <artifactId>nashorn-core</artifactId>
             <version>15.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>1.8.0</version>
+        </dependency>
     </dependencies>
     <build>
         <resources>


### PR DESCRIPTION
Without this dependency, when trying to run schemaspy with a Clickhouse JDBC against a Clickhouse database, it throws an exception:
`java.sql.SQLException: LZ4 is not supported. Please disable compression(compress=0), modify the algorithm(e.g. compress_algorithm=gzip), or add the missing libraries to the classpath., server ClickHouseNode`