### PR TITLE
Update commandline.rst - fix schemaSpec reference

### DIFF
--- a/docs/source/configuration/commandline.rst
+++ b/docs/source/configuration/commandline.rst
@@ -62,7 +62,7 @@ Processing
 [-schemas listOfSchemas]
     List of schemas to analyze, separated by ``,``
 [-all]
-    Try to analyze all schemas in database, schemas can be excluded with ``-schemSpec`` which as defaults set by databaseType
+    Try to analyze all schemas in database, schemas can be excluded with ``-schemaSpec`` which as defaults set by databaseType
 [-schemaSpec schemaRegEx]
     Schemas to analyze, default to all, might be specified by databaseType.
 [-dbthreads number]


### PR DESCRIPTION
There was a reference to a "-schemSpec" argument that should be "-schemaSpec".