### PR TITLE
[Informix][Issue 1472] Improve Performance in selectRoutineParametersSql and selectRoutinesSql

### DIFF
--- a/src/main/resources/org/schemaspy/types/informix.properties
+++ b/src/main/resources/org/schemaspy/types/informix.properties
@@ -29,12 +29,12 @@ security_type, \
 is_deterministic, \
 routine_comment \
 from ( select p.procid, p.procname,p.langid, \
-case p.isproc when "f" then "function" when "t" then "procedure" end as routine_type, \
+CASE p.isproc WHEN "f" THEN "function" WHEN "t" THEN "procedure" end as routine_type, \
 l.langname as routine_body, \
 b.data as routine_definition, \
 b.seqno, \
 'N/A' as sql_data_access, \
-case LOWER (p.mode) when "d" then "dba" when "o" then "Owner" when "p" then "Protected" when "r" then "Restricted" when "t" then "trigger" end as security_type, \
+CASE LOWER (p.mode) WHEN "d" THEN "dba" WHEN "o" THEN "Owner" WHEN "p" THEN "Protected" WHEN "r" THEN "Restricted" WHEN "t" THEN "trigger" end as security_type, \
 p.variant as is_deterministic, \
 "N / A" as routine_comment \
 from sysprocedures p \
@@ -42,43 +42,47 @@ join sysroutinelangs l on p.langid = l.langid \
 join sysprocbody b on p.procid = b.procid and b.datakey = 'T' \
 order by p.procid, b.seqno) t
 
-selectRoutineParametersSql=select p.procname || '(' || ifx_param_types(p.procid) || ')' as specific_name, c.paramname as parameter_name, \
+selectRoutineParametersSql=select procname || '(' || ifx_param_types(procid) || ')' as specific_name, \
+parameter_name, \
+dtd_identifier, \
+parameter_mode \
+from ( select p.procname, p.procid, c.paramname as parameter_name, \
 CASE \
-WHEN MOD(c.paramtype,256)=0 THEN 'CHAR' \
-WHEN MOD(c.paramtype,256)=1 THEN 'SMALLINT' \
-WHEN MOD(c.paramtype,256)=2 THEN 'INTEGER' \
-WHEN MOD(c.paramtype,256)=3 THEN 'FLOAT' \
-WHEN MOD(c.paramtype,256)=4 THEN 'SMALLFLOAT' \
-WHEN MOD(c.paramtype,256)=5 THEN 'DECIMAL' \
-WHEN MOD(c.paramtype,256)=6 THEN 'SERIAL' \
-WHEN MOD(c.paramtype,256)=7 THEN 'DATE' \
-WHEN MOD(c.paramtype,256)=8 THEN 'MONEY' \
-WHEN MOD(c.paramtype,256)=9 THEN 'NULL' \
-WHEN MOD(c.paramtype,256)=10 THEN 'DATETIME' \
-WHEN MOD(c.paramtype,256)=11 THEN 'BYTE' \
-WHEN MOD(c.paramtype,256)=12 THEN 'TEXT' \
-WHEN MOD(c.paramtype,256)=13 THEN 'VARCHAR' \
-WHEN MOD(c.paramtype,256)=14 THEN 'INTERVAL' \
-WHEN MOD(c.paramtype,256)=15 THEN 'NCHAR' \
-WHEN MOD(c.paramtype,256)=16 THEN 'NVARCHAR' \
-WHEN MOD(c.paramtype,256)=17 THEN 'INT8' \
-WHEN MOD(c.paramtype,256)=18 THEN 'SERIAL8' \
-WHEN MOD(c.paramtype,256)=19 THEN 'SET' \
-WHEN MOD(c.paramtype,256)=20 THEN 'MULTISET' \
-WHEN MOD(c.paramtype,256)=21 THEN 'LIST' \
-WHEN MOD(c.paramtype,256)=22 THEN 'ROW (unnamed)' \
-WHEN MOD(c.paramtype,256)=23 THEN 'COLLECTION' \
-WHEN MOD(c.paramtype,256)=40 THEN 'LVARCHAR fixed-length opaque types' \
-WHEN MOD(c.paramtype,256)=41 THEN 'BLOB, BOOLEAN, CLOB variable-length opaque types' \
-WHEN MOD(c.paramtype,256)=43 THEN 'LVARCHAR (client-side only)' \
-WHEN MOD(c.paramtype,256)=45 THEN 'BOOLEAN' \
-WHEN MOD(c.paramtype,256)=52 THEN 'BIGINT' \
-WHEN MOD(c.paramtype,256)=53 THEN 'BIGSERIAL' \
-WHEN MOD(c.paramtype,256)=2061 THEN 'IDSSECURITYLABEL' \
-WHEN MOD(c.paramtype,256)=4118 THEN 'ROW (named)' \
-ELSE TO_CHAR(c.paramtype) \
-END AS dtd_identifier, \
-case c.paramattr when 0 then "Unknown" when 1 then "INPUT" when 2 then "INOUT" when 3 then "Multi Return" when 4 then "OUT" when 5 then "RETURN" end as parameter_mode \
+WHEN mod(c.paramtype, 256)= 0 THEN 'CHAR' \
+WHEN mod(c.paramtype, 256)= 1 THEN 'SMALLINT' \
+WHEN mod(c.paramtype, 256)= 2 THEN 'INTEGER' \
+WHEN mod(c.paramtype, 256)= 3 THEN 'FLOAT' \
+WHEN mod(c.paramtype, 256)= 4 THEN 'SMALLFLOAT' \
+WHEN mod(c.paramtype, 256)= 5 THEN 'DECIMAL' \
+WHEN mod(c.paramtype, 256)= 6 THEN 'SERIAL' \
+WHEN mod(c.paramtype, 256)= 7 THEN 'DATE' \
+WHEN mod(c.paramtype, 256)= 8 THEN 'MONEY' \
+WHEN mod(c.paramtype, 256)= 9 THEN 'NULL' \
+WHEN mod(c.paramtype, 256)= 10 THEN 'DATETIME' \
+WHEN mod(c.paramtype, 256)= 11 THEN 'BYTE' \
+WHEN mod(c.paramtype, 256)= 12 THEN 'TEXT' \
+WHEN mod(c.paramtype, 256)= 13 THEN 'VARCHAR' \
+WHEN mod(c.paramtype, 256)= 14 THEN 'INTERVAL' \
+WHEN mod(c.paramtype, 256)= 15 THEN 'NCHAR' \
+WHEN mod(c.paramtype, 256)= 16 THEN 'NVARCHAR' \
+WHEN mod(c.paramtype, 256)= 17 THEN 'INT8' \
+WHEN mod(c.paramtype, 256)= 18 THEN 'SERIAL8' \
+WHEN mod(c.paramtype, 256)= 19 THEN 'SET' \
+WHEN mod(c.paramtype, 256)= 20 THEN 'MULTISET' \
+WHEN mod(c.paramtype, 256)= 21 THEN 'LIST' \
+WHEN mod(c.paramtype, 256)= 22 THEN 'ROW (unnamed)' \
+WHEN mod(c.paramtype, 256)= 23 THEN 'COLLECTION' \
+WHEN mod(c.paramtype, 256)= 40 THEN 'LVARCHAR fixed-length opaque types' \
+WHEN mod(c.paramtype, 256)= 41 THEN 'BLOB, BOOLEAN, CLOB variable-length opaque types' \
+WHEN mod(c.paramtype, 256)= 43 THEN 'LVARCHAR (client-side only)' \
+WHEN mod(c.paramtype, 256)= 45 THEN 'BOOLEAN' \
+WHEN mod(c.paramtype, 256)= 52 THEN 'BIGINT' \
+WHEN mod(c.paramtype, 256)= 53 THEN 'BIGSERIAL' \
+WHEN mod(c.paramtype, 256)= 2061 THEN 'IDSSECURITYLABEL' \
+WHEN mod(c.paramtype, 256)= 4118 THEN 'ROW (named)' \
+ELSE TO_CHAR(c.paramtype) end as dtd_identifier, \
+CASE \
+c.paramattr WHEN 0 THEN "unknown" WHEN 1 THEN "input" WHEN 2 THEN "inout" WHEN 3 THEN "Multi return" WHEN 4 THEN "out" WHEN 5 THEN "return" end as parameter_mode \
 from sysprocedures p \
 join sysproccolumns c on p.procid = c.procid \
-order by p.procid, c.paramid
+order by p.procid, c.paramid) s

--- a/src/main/resources/org/schemaspy/types/informix.properties
+++ b/src/main/resources/org/schemaspy/types/informix.properties
@@ -18,16 +18,29 @@ multirowdata=true
 
 selectCheckConstraintsSql=select t.tabname as table_name, c.constrname as constraint_name, k.checktext as text from sysconstraints c,syschecks k,systables t where c.constrid = k.constrid and c.tabid = t.tabid and c.constrtype = 'C' and k.type = 'T' order by k.seqno
 
-selectRoutinesSql=SELECT p.procname || '(' || ifx_param_types(p.procid) || ')' AS routine_name, \
-case p.isproc when "f" then "Function" when "t" then "Procedure" end as routine_type, \
-ifx_ret_types(p.procid) as dtd_identifier, \
+selectRoutinesSql=select procname || '(' || ifx_param_types(procid) || ')' as routine_name, \
+routine_type, \
+ifx_ret_types(procid) as dtd_identifier, \
+routine_body, \
+routine_definition, \
+seqno, \
+sql_data_access, \
+security_type, \
+is_deterministic, \
+routine_comment \
+from ( select p.procid, p.procname,p.langid, \
+case p.isproc when "f" then "function" when "t" then "procedure" end as routine_type, \
 l.langname as routine_body, \
-b.data as routine_definition, b.seqno, 'N/A' as sql_data_access, case LOWER (p.mode) when "d" then "DBA" when "o" then "Owner" when "p" then "Protected" when "r" then "Restricted" when "t" then "trigger" end as security_type, \
-p.variant as is_deterministic, "N/A" as routine_comment \
+b.data as routine_definition, \
+b.seqno, \
+'N/A' as sql_data_access, \
+case LOWER (p.mode) when "d" then "dba" when "o" then "Owner" when "p" then "Protected" when "r" then "Restricted" when "t" then "trigger" end as security_type, \
+p.variant as is_deterministic, \
+"N / A" as routine_comment \
 from sysprocedures p \
 join sysroutinelangs l on p.langid = l.langid \
 join sysprocbody b on p.procid = b.procid and b.datakey = 'T' \
-order by p.procid, b.seqno
+order by p.procid, b.seqno) t
 
 selectRoutineParametersSql=select p.procname || '(' || ifx_param_types(p.procid) || ')' as specific_name, c.paramname as parameter_name, \
 CASE \


### PR DESCRIPTION
This PR is to improve performance in selectRoutineParametersSql and selectRoutinesSql. See #1472 
The original queries use functions in the same queries that make the queries slow in databases with a higher number of routines. I refactored the queries into sub-queries and the results are better in terms of performance.

Please let me know If some changes are needed.

Best Regards.
João Gaspar