### PR TITLE
chore(mssql): update mssql.properties to support SQL Server 2005+ JDBC driver

### DIFF
--- a/src/main/resources/org/schemaspy/types/mssql.properties
+++ b/src/main/resources/org/schemaspy/types/mssql.properties
@@ -3,13 +3,13 @@
 # for configuration / customization details
 #
 dbms=Microsoft SQL Server
-description=2000+
-connectionSpec=jdbc:microsoft:sqlserver://<hostOptionalPort>;databaseName=<db>
+description=2005+
+connectionSpec=jdbc:sqlserver://<hostOptionalPort>;databaseName=<db>
 host=host where database resides with optional port
 port=port database is listening on
 db=database name
 
-driver=com.microsoft.sqlserver.jdbc.SQLServerDriver,com.microsoft.jdbc.sqlserver.SQLServerDriver
+driver=com.microsoft.sqlserver.jdbc.SQLServerDriver
 
 # return text that represents a specific :view / :schema
 selectViewSql=select text AS view_definition from syscomments sc, sysobjects so where sc.id=so.id and so.name=:table


### PR DESCRIPTION
This pull request updates the `types/mssql.properties` file to support Microsoft SQL Server 2005 and later versions, aligning with the modern JDBC driver. The changes include:

- Updated `description` from "2000+" to "2005+" to reflect support for SQL Server 2005 and later, as the modern JDBC driver (`com.microsoft.sqlserver.jdbc.SQLServerDriver`) and connection string (`jdbc:sqlserver://`) were standardized starting with SQL Server 2005.
- Modified `connectionSpec` from `jdbc:microsoft:sqlserver` to `jdbc:sqlserver` to align with the standard JDBC URL format for SQL Server 2005+.
- Removed the deprecated `com.microsoft.jdbc.sqlserver.SQLServerDriver` from the `driver` list, retaining only `com.microsoft.sqlserver.jdbc.SQLServerDriver`.

These changes modernize the configuration for SQL Server, discontinuing support for the outdated SQL Server 2000. This is a maintenance update to ensure compatibility with current SQL Server versions.

Related Issue: 
The following connection failure was reported with the outdated configuration:
WARN  - Connection Failure
Failed to connect to database URL [jdbc:microsoft:sqlserver://xxx.xxx.xxx.xxx:14443;databaseName=temp01] Cannot connect to 'jdbc:microsoft:sqlserver://[192.168.100.34:14443](xxx.xxx.xxx.xxx:14443);databaseName=temp01' with driver 'com.microsoft.sqlserver.jdbc.SQLServerDriver,com.microsoft.jdbc.sqlserver.SQLServerDriver'


Testing:
- Verified that the updated `mssql.properties` configuration works with SchemaSpy for SQL Server 2005, 2008, and later versions.
- Ensured the updated JDBC driver and connection string are compatible with modern SQL Server instances (tested with SQL Server 2019).

Please review and let me know if any further changes are needed!